### PR TITLE
Run Steam presence bridge via master bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env.worker
 .env.*
 __pycache__
+node_modules/
 /Backup
 /logs
 
@@ -17,6 +18,8 @@ install_windows_service.py
 *env*
 *.env*
 *.json
+!service/steam_presence/package.json
+!service/steam_presence/package-lock.json
 *.db-shm
 *.db-wal
 *.db

--- a/main_bot.py
+++ b/main_bot.py
@@ -23,6 +23,8 @@ from discord.ext import commands
 # --- DEBUG: Herkunft der geladenen Dateien ausgeben ---
 import sys as _sys, os as _os, importlib, inspect, logging as _logging, hashlib
 
+from steam import SteamPresenceServiceManager
+
 def _log_src(modname: str):
     try:
         m = importlib.import_module(modname)
@@ -212,6 +214,8 @@ class MasterBot(commands.Bot):
         self.startup_time = _dt.datetime.now(tz=tz)
         self.cog_status: Dict[str, str] = {}
 
+        self.steam_service = SteamPresenceServiceManager()
+
         try:
             self.per_cog_unload_timeout = float(os.getenv("PER_COG_UNLOAD_TIMEOUT", "3.0"))
         except ValueError:
@@ -373,6 +377,16 @@ class MasterBot(commands.Bot):
         except Exception as e:
             logging.error(f"Failed to sync slash commands: {e}")
 
+        if self.steam_service.auto_start:
+            logging.info(
+                "Scheduling steam presence service auto-start (cmd='%s', cwd=%s)",
+                self.steam_service.start_command,
+                self.steam_service.service_dir,
+            )
+            asyncio.create_task(self._start_steam_service_safely())
+        else:
+            logging.info("AUTO_START_STEAM_SERVICE disabled; steam presence service not started automatically")
+
         logging.info("Master Bot setup completed")
 
     async def on_ready(self):
@@ -384,6 +398,14 @@ class MasterBot(commands.Bot):
         runtime_loaded = self.active_cogs()
         logging.info(f"Loaded cogs (runtime): {len(runtime_loaded)}")
         logging.info(f"Loaded cogs: {len(runtime_loaded)}/{len(self.cogs_list)}")
+
+        steam_status = self.steam_service.status()
+        logging.info(
+            "Steam presence service • auto_start=%s • running=%s • pid=%s",
+            steam_status.auto_start,
+            steam_status.running,
+            steam_status.pid,
+        )
 
         # TempVoice Log (neu)
         try:
@@ -398,6 +420,16 @@ class MasterBot(commands.Bot):
             logging.getLogger().debug("TempVoice Ready-Log fehlgeschlagen (ignoriert): %r", e)
 
         asyncio.create_task(self.hourly_health_check())
+
+    async def _start_steam_service_safely(self):
+        try:
+            started = await self.steam_service.ensure_started()
+            if started:
+                logging.info("Steam presence service launched by master bot")
+            else:
+                logging.info("Steam presence service already running when master bot attempted start")
+        except Exception as exc:
+            logging.error(f"Failed to start steam presence service: {exc}")
 
     async def load_all_cogs(self):
         logging.info("Loading all cogs in parallel...")
@@ -581,6 +613,13 @@ class MasterBot(commands.Bot):
     async def close(self):
         logging.info("Master Bot shutting down...")
 
+        try:
+            stopped = await self.steam_service.stop()
+            if stopped:
+                logging.info("Steam presence service stopped as part of master shutdown")
+        except Exception as exc:
+            logging.error(f"Failed to stop steam presence service during shutdown: {exc}")
+
         # 1) Alle Cogs entladen (parallel/sequenziell mit Timeout pro Cog)
         to_unload = [ext for ext in list(self.extensions.keys()) if ext.startswith("cogs.")]
         if to_unload:
@@ -634,11 +673,82 @@ class MasterControlCog(commands.Cog):
                 f"`{p}master discover` - Neue Cogs entdecken (ohne laden)\n"
                 f"`{p}master unload <muster>` - Cogs mit Muster entladen\n"
                 f"`{p}master unloadtree <prefix>` - ganzen Cog-Ordner entladen\n"
+                f"`{p}master steam …` - Steam Presence Service steuern\n"
                 f"`{p}master shutdown` - Bot beenden"
             ),
             inline=False,
         )
         await ctx.send(embed=embed)
+
+    def _format_timestamp(self, ts: float | None) -> str:
+        if not ts:
+            return "—"
+        tz = self.bot.startup_time.tzinfo or pytz.timezone("Europe/Berlin")
+        return _dt.datetime.fromtimestamp(ts, tz=tz).strftime("%d.%m.%Y %H:%M:%S")
+
+    @master_control.group(name="steam", invoke_without_command=True)
+    async def master_steam(self, ctx):
+        status = self.bot.steam_service.status()
+        embed = discord.Embed(title="Steam Presence Service", color=0x1B2838)
+        embed.add_field(name="Auto-Start", value="✅ Aktiv" if status.auto_start else "⛔ Deaktiviert", inline=True)
+        embed.add_field(name="Status", value="🟢 Läuft" if status.running else "🔴 Gestoppt", inline=True)
+        embed.add_field(name="PID", value=status.pid or "—", inline=True)
+        embed.add_field(name="Restarts", value=str(status.restarts), inline=True)
+        embed.add_field(name="Start-Befehl", value=f"`{status.cmd}`", inline=False)
+        embed.add_field(name="Arbeitsverzeichnis", value=f"`{status.cwd}`", inline=False)
+        embed.add_field(name="Letzter Start", value=self._format_timestamp(status.last_start), inline=True)
+        embed.add_field(name="Letzter Exit", value=self._format_timestamp(status.last_exit), inline=True)
+        if not status.running and status.returncode is not None:
+            embed.add_field(name="Exit-Code", value=str(status.returncode), inline=True)
+        embed.set_footer(text="Subcommands: start, stop, restart, tail [limit] [stdout|stderr]")
+        await ctx.send(embed=embed)
+
+    @master_steam.command(name="start")
+    async def master_steam_start(self, ctx):
+        try:
+            started = await self.bot.steam_service.ensure_started()
+        except Exception as exc:
+            await ctx.send(f"❌ Start fehlgeschlagen: `{exc}`")
+            return
+        if started:
+            await ctx.send("✅ Steam Presence Service wurde gestartet.")
+        else:
+            await ctx.send("ℹ️ Service läuft bereits.")
+
+    @master_steam.command(name="stop")
+    async def master_steam_stop(self, ctx):
+        try:
+            stopped = await self.bot.steam_service.stop()
+        except Exception as exc:
+            await ctx.send(f"❌ Stop fehlgeschlagen: `{exc}`")
+            return
+        if stopped:
+            await ctx.send("🛑 Steam Presence Service wurde gestoppt.")
+        else:
+            await ctx.send("ℹ️ Service war bereits gestoppt.")
+
+    @master_steam.command(name="restart")
+    async def master_steam_restart(self, ctx):
+        try:
+            await self.bot.steam_service.restart()
+        except Exception as exc:
+            await ctx.send(f"❌ Restart fehlgeschlagen: `{exc}`")
+            return
+        await ctx.send("🔄 Steam Presence Service wurde neu gestartet.")
+
+    @master_steam.command(name="tail")
+    async def master_steam_tail(self, ctx, limit: int = 20, channel: str = "stdout"):
+        limit = max(1, min(limit, 100))
+        stderr = channel.lower() in {"stderr", "err", "error"}
+        lines = self.bot.steam_service.tail(stderr=stderr, limit=limit)
+        if not lines:
+            await ctx.send("(Keine Ausgaben verfügbar)")
+            return
+        lang = "diff" if stderr else ""
+        content = "\n".join(lines)
+        if len(content) > 1900:
+            content = content[-1900:]
+        await ctx.send(f"```{lang}\n{content}\n```")
 
     @master_control.command(name="status", aliases=["s"])
     async def master_status(self, ctx):
@@ -675,6 +785,17 @@ class MasterControlCog(commands.Cog):
         if errs:
             err_short = [f"❌ {e.split('.')[-1]}" for e in errs]
             embed.add_field(name="⚠️ Fehlerhafte Cogs (letzter Versuch)", value="\n".join(err_short), inline=False)
+
+        steam_status = self.bot.steam_service.status()
+        lines = [
+            f"Auto-Start: {'✅ an' if steam_status.auto_start else '⛔ aus'}",
+            f"Status: {'🟢 läuft' if steam_status.running else '🔴 gestoppt'}",
+            f"PID: {steam_status.pid or '—'}",
+            f"Restarts: {steam_status.restarts}",
+        ]
+        if not steam_status.running and steam_status.returncode is not None:
+            lines.append(f"Exit-Code: {steam_status.returncode}")
+        embed.add_field(name="🖥️ Steam Presence Service", value="\n".join(lines), inline=False)
 
         await ctx.send(embed=embed)
 

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -2,6 +2,10 @@
 # Re-export der Submodule, damit "from service import db" etc. funktioniert.
 from . import db
 try:
+    from . import steam  # Rich-Presence/Steam-Hilfen
+except Exception:
+    steam = None
+try:
     from . import socket_bus  # falls vorhanden
 except Exception:
     socket_bus = None
@@ -10,4 +14,4 @@ try:
 except Exception:
     worker_client = None
 
-__all__ = ["db", "socket_bus", "worker_client"]
+__all__ = ["db", "socket_bus", "worker_client", "steam"]

--- a/service/db.py
+++ b/service/db.py
@@ -276,6 +276,26 @@ def init_schema(conn: Optional[sqlite3.Connection] = None) -> None:
               in_match_now_strict INTEGER DEFAULT 0
             );
 
+            -- Steam Rich Presence Cache (gefüllt vom node-steam-user Service)
+            CREATE TABLE IF NOT EXISTS steam_rich_presence(
+              steam_id TEXT PRIMARY KEY,
+              app_id INTEGER,
+              status TEXT,
+              display TEXT,
+              player_group TEXT,
+              player_group_size INTEGER,
+              connect TEXT,
+              raw_json TEXT,
+              last_update INTEGER
+            );
+
+            -- Optionale zusätzliche Watchlist für den Presence-Service
+            CREATE TABLE IF NOT EXISTS steam_presence_watchlist(
+              steam_id TEXT PRIMARY KEY,
+              note TEXT,
+              added_at INTEGER DEFAULT (strftime('%s','now'))
+            );
+
             -- Live-Lane-Status (pro Voice-Channel)
             CREATE TABLE IF NOT EXISTS live_lane_state(
               channel_id  INTEGER PRIMARY KEY,
@@ -305,6 +325,7 @@ def init_schema(conn: Optional[sqlite3.Connection] = None) -> None:
             c.execute("CREATE INDEX IF NOT EXISTS idx_llm_checked  ON live_lane_members(checked_ts)")
             c.execute("CREATE INDEX IF NOT EXISTS idx_steam_links_user  ON steam_links(user_id)")
             c.execute("CREATE INDEX IF NOT EXISTS idx_steam_links_steam ON steam_links(steam_id)")
+            c.execute("CREATE INDEX IF NOT EXISTS idx_rich_presence_updated ON steam_rich_presence(last_update)")
             c.execute("CREATE INDEX IF NOT EXISTS idx_ranks_rank ON ranks(rank)")
         except sqlite3.Error as e:
             logger.debug("Optionale Index-Erstellung übersprungen: %s", e, exc_info=True)

--- a/service/steam_presence/README.md
+++ b/service/steam_presence/README.md
@@ -1,0 +1,78 @@
+# Deadlock Steam Rich Presence Service
+
+Dieser Node.js-Service loggt sich mit `steam-user` ein und schreibt die Rich-Presence-Daten
+für überwachte Accounts in die gemeinsame SQLite-Datenbank (`steam_rich_presence`).
+Dadurch kann der Python-basierte Discord-Bot präzisere Match- und Lobby-Zustände erkennen.
+
+## Voraussetzungen
+
+- Node.js 18+
+- Ein eigener Steam-Account für den Bot, der mit den zu überwachenden Accounts befreundet ist
+- Zugriff auf dieselbe SQLite-DB, die auch der Discord-Bot nutzt (`DEADLOCK_DB_PATH` oder `DEADLOCK_DB_DIR`)
+
+## Konfiguration (Environment)
+
+Du kannst die Variablen entweder klassisch in deiner Shell/als Dienst setzen oder über
+eine `.env`-Datei im Verzeichnis `service/steam_presence` hinterlegen – sie wird beim
+Start automatisch eingelesen.
+
+| Variable | Beschreibung |
+| --- | --- |
+| `STEAM_BOT_USERNAME` / `STEAM_LOGIN` | Steam-Loginname des Bot-Accounts |
+| `STEAM_BOT_PASSWORD` | Passwort, falls kein Login-Key verwendet wird |
+| `STEAM_LOGIN_KEY` | Optionaler gespeicherter Login-Key (alternativ zu Passwort) |
+| `STEAM_LOGIN_KEY_PATH` | Dateipfad zum Speichern/Laden des Login-Keys |
+| `STEAM_TOTP_SECRET` | Shared-Secret für 2FA (Steam Guard), erzeugt beim Einrichten der Mobile App |
+| `STEAM_GUARD_CODE` | Einmaliger Steam-Guard-Code (Fallback, falls kein TOTP). Wird beim Start verbraucht |
+| `DEADLOCK_DB_PATH` / `DEADLOCK_DB_DIR` | Pfad bzw. Verzeichnis zur SQLite-Datenbank |
+| `DEADLOCK_APP_ID` | Steam-AppID von Deadlock (Default: `1422450`) |
+| `RP_WATCH_REFRESH_SEC` | Intervall zum Nachladen der Watchlist (Sekunden) |
+| `RP_POLL_INTERVAL_MS` | Intervall zum Abfragen der Rich Presence (Millisekunden) |
+| `LOG_LEVEL` | `error`, `warn`, `info` (Default) oder `debug` |
+| `AUTO_START_STEAM_SERVICE` | Vom Master-Bot gesteuert: `1` (Default) startet den Service automatisch |
+| `STEAM_SERVICE_AUTO_INSTALL` | `1` (Default) führt vor dem Start einmalig `npm install` aus |
+| `STEAM_SERVICE_CMD` | Optionaler alternativer Startbefehl (Default: `npm run start`) |
+| `STEAM_SERVICE_INSTALL_CMD` | Optionaler Installationsbefehl (Default: `npm install`) |
+
+### Steam Guard / 2FA
+
+Es gibt keine interaktive Abfrage – der Dienst benötigt den Steam-Guard-Code bereits beim
+Start. Am bequemsten ist es, das `STEAM_TOTP_SECRET` aus der Steam-Mobile-App zu
+übernehmen; daraus generiert der Bot bei jedem Login automatisch einen gültigen Code.
+Alternativ kannst du einmalig `STEAM_GUARD_CODE` setzen (z. B. in der `.env`). Nach der
+Verwendung wird er verworfen und du musst beim nächsten Start einen neuen Code hinterlegen.
+
+## Starten
+
+```bash
+npm install
+npm run start
+```
+
+Die Watchlist ergibt sich automatisch aus allen verknüpften Steam-IDs (`steam_links`) plus
+optional manuellen Einträgen in `steam_presence_watchlist`.
+
+> **Hinweis:** Wenn du den Python-Master-Bot verwendest, kannst du das manuelle Starten
+> überspringen. Der Bot bringt einen Supervisor mit (`SteamPresenceServiceManager`), der den
+> Node-Prozess beim Hochfahren automatisch startet (sofern `AUTO_START_STEAM_SERVICE` nicht
+> deaktiviert ist) und bei Abstürzen neu startet. Über Discord stehen dir zusätzliche
+> Befehle zur Verfügung:
+>
+> - `!master steam` – zeigt Status, Pfad und letzte Start-/Stoppzeiten an
+> - `!master steam start|stop|restart` – manuelles Steuern des Dienstes
+> - `!master steam tail [limit] [stdout|stderr]` – letze Logzeilen ausgeben
+
+## Betrieb mit den bestehenden Discord-Bots
+
+- **Gleiche Datenbank:** Stelle sicher, dass sowohl der Python-Discord-Bot als auch dieser
+  Service dieselbe SQLite-Datei verwenden (`DEADLOCK_DB_PATH`).
+- **Feature ist aktiv:** Im Python-Bot ist keine zusätzliche Konfiguration notwendig –
+  solange `ENABLE_RICH_PRESENCE` nicht auf `0` gesetzt ist, fließen die Daten automatisch
+  in die Match-Heuristik ein.
+- **Gemeinsamer Start:** Lass den Node-Service parallel zum Discord-Bot laufen (z. B. über
+  `pm2`, `systemd`, den Windows-Taskplaner oder einen zweiten `start`-Befehl neben dem
+  bestehenden `start_master_bot.bat`). Wichtig ist nur, dass beide Prozesse auf dieselbe
+  Datenbank zugreifen.
+
+Eingehende Freundschaftsanfragen an den Bot-Account werden automatisch angenommen, damit
+neue Spieler sofort überwacht werden können.

--- a/service/steam_presence/index.js
+++ b/service/steam_presence/index.js
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+/**
+ * Steam Rich Presence bridge for Deadlock bots.
+ * Logs into Steam via steam-user and persists rich presence snapshots
+ * into the shared SQLite database so the Python bot can evaluate lobby/match states.
+ */
+
+require('dotenv').config();
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const SteamUser = require('steam-user');
+const SteamTotp = require('steam-totp');
+const Database = require('better-sqlite3');
+
+const APP_ID = parseInt(process.env.DEADLOCK_APP_ID || '1422450', 10);
+const WATCH_REFRESH_MS = parseInt(process.env.RP_WATCH_REFRESH_SEC || '30', 10) * 1000;
+const POLL_INTERVAL_MS = parseInt(process.env.RP_POLL_INTERVAL_MS || '15000', 10);
+const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const LOG_LEVEL = (process.env.LOG_LEVEL || 'info').toLowerCase();
+const LOG_THRESHOLD = Object.prototype.hasOwnProperty.call(LOG_LEVELS, LOG_LEVEL)
+  ? LOG_LEVELS[LOG_LEVEL]
+  : LOG_LEVELS.info;
+
+function log(level, message, extra = undefined) {
+  const lvl = LOG_LEVELS[level];
+  if (lvl === undefined || lvl > LOG_THRESHOLD) {
+    return;
+  }
+  const payload = {
+    time: new Date().toISOString(),
+    level,
+    msg: message,
+  };
+  if (extra && typeof extra === 'object') {
+    for (const [k, v] of Object.entries(extra)) {
+      if (v !== undefined) {
+        payload[k] = v;
+      }
+    }
+  }
+  console.log(JSON.stringify(payload));
+}
+
+function resolveDbPath() {
+  if (process.env.DEADLOCK_DB_PATH) {
+    return path.resolve(process.env.DEADLOCK_DB_PATH);
+  }
+  const baseDir = process.env.DEADLOCK_DB_DIR
+    ? path.resolve(process.env.DEADLOCK_DB_DIR)
+    : path.join(os.homedir(), 'Documents', 'Deadlock', 'service');
+  return path.join(baseDir, 'deadlock.sqlite3');
+}
+
+const dbPath = resolveDbPath();
+log('info', 'Using SQLite database', { dbPath });
+const db = new Database(dbPath);
+
+db.pragma('journal_mode = WAL');
+db.pragma('synchronous = NORMAL');
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_rich_presence (
+    steam_id TEXT PRIMARY KEY,
+    app_id INTEGER,
+    status TEXT,
+    display TEXT,
+    player_group TEXT,
+    player_group_size INTEGER,
+    connect TEXT,
+    raw_json TEXT,
+    last_update INTEGER
+  )
+`).run();
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_presence_watchlist (
+    steam_id TEXT PRIMARY KEY,
+    note TEXT,
+    added_at INTEGER DEFAULT (strftime('%s','now'))
+  )
+`).run();
+
+const upsertPresence = db.prepare(`
+  INSERT INTO steam_rich_presence(steam_id, app_id, status, display, player_group, player_group_size, connect, raw_json, last_update)
+  VALUES (@steam_id, @app_id, @status, @display, @player_group, @player_group_size, @connect, @raw_json, @last_update)
+  ON CONFLICT(steam_id) DO UPDATE SET
+    app_id=excluded.app_id,
+    status=excluded.status,
+    display=excluded.display,
+    player_group=excluded.player_group,
+    player_group_size=excluded.player_group_size,
+    connect=excluded.connect,
+    raw_json=excluded.raw_json,
+    last_update=excluded.last_update
+`);
+
+const watchlistQuery = db.prepare(`
+  SELECT DISTINCT steam_id FROM (
+    SELECT steam_id FROM steam_links
+    UNION
+    SELECT steam_id FROM steam_presence_watchlist
+  )
+  WHERE steam_id IS NOT NULL AND steam_id != ''
+`);
+
+const client = new SteamUser();
+client.setOption('promptSteamGuardCode', false);
+
+let isLoggedOn = false;
+let reconnectTimer = null;
+const watchList = new Map();
+
+const loginAccount = process.env.STEAM_BOT_USERNAME || process.env.STEAM_LOGIN || process.env.STEAM_ACCOUNT;
+let loginKey = process.env.STEAM_LOGIN_KEY || '';
+const loginKeyPath = process.env.STEAM_LOGIN_KEY_PATH ? path.resolve(process.env.STEAM_LOGIN_KEY_PATH) : '';
+const password = process.env.STEAM_BOT_PASSWORD || process.env.STEAM_PASSWORD;
+const totpSecret = process.env.STEAM_TOTP_SECRET || '';
+let guardCode = process.env.STEAM_GUARD_CODE || '';
+
+if (!loginAccount) {
+  log('error', 'Missing STEAM_BOT_USERNAME/STEAM_LOGIN env variable');
+  process.exit(1);
+}
+
+if (!loginKey && loginKeyPath && fs.existsSync(loginKeyPath)) {
+  try {
+    loginKey = fs.readFileSync(loginKeyPath, 'utf8').trim();
+    if (loginKey) {
+      log('info', 'Loaded login key from file', { loginKeyPath });
+    }
+  } catch (err) {
+    log('warn', 'Failed to read login key file', { loginKeyPath, error: err.message });
+  }
+}
+
+function scheduleReconnect(delayMs = 10000) {
+  if (reconnectTimer) {
+    return;
+  }
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    logOn();
+  }, delayMs);
+}
+
+function logOn() {
+  if (isLoggedOn) {
+    return;
+  }
+  const options = {
+    accountName: loginAccount,
+    rememberPassword: true,
+  };
+
+  if (loginKey) {
+    options.loginKey = loginKey;
+  } else if (password) {
+    options.password = password;
+    if (totpSecret) {
+      options.twoFactorCode = SteamTotp.generateAuthCode(totpSecret);
+    } else if (guardCode) {
+      options.twoFactorCode = guardCode;
+      guardCode = '';
+    }
+  } else {
+    log('error', 'Missing STEAM_BOT_PASSWORD or STEAM_LOGIN_KEY');
+    process.exit(1);
+  }
+
+  log('info', 'Logging in to Steam', { account: loginAccount });
+  client.logOn(options);
+}
+
+function safeRequestRichPresence(steamID) {
+  try {
+    client.requestFriendRichPresence(steamID, APP_ID);
+  } catch (err) {
+    log('debug', 'requestFriendRichPresence failed', { steamId: steamID.toString(), error: err.message });
+  }
+}
+
+function refreshWatchList() {
+  let rows = [];
+  try {
+    rows = watchlistQuery.all();
+  } catch (err) {
+    log('error', 'Failed to read watchlist from DB', { error: err.message });
+    return;
+  }
+  const next = new Set();
+  for (const row of rows) {
+    const sid = String(row.steam_id || '').trim();
+    if (!sid) {
+      continue;
+    }
+    next.add(sid);
+    if (!watchList.has(sid)) {
+      try {
+        const steamID = new SteamUser.SteamID(sid);
+        watchList.set(sid, steamID);
+        log('info', 'Added SteamID to watch list', { steamId: sid });
+        if (isLoggedOn) {
+          safeRequestRichPresence(steamID);
+        }
+      } catch (err) {
+        log('warn', 'Ignoring invalid SteamID', { steamId: sid, error: err.message });
+      }
+    }
+  }
+  for (const sid of Array.from(watchList.keys())) {
+    if (!next.has(sid)) {
+      watchList.delete(sid);
+      log('info', 'Removed SteamID from watch list', { steamId: sid });
+    }
+  }
+}
+
+function pollPresence() {
+  if (!isLoggedOn || watchList.size === 0) {
+    return;
+  }
+  const ids = Array.from(watchList.values());
+  const chunkSize = 25;
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize);
+    for (const sid of chunk) {
+      safeRequestRichPresence(sid);
+    }
+  }
+}
+
+client.on('loggedOn', () => {
+  isLoggedOn = true;
+  log('info', 'Logged in to Steam', { account: loginAccount });
+  client.setPersona(SteamUser.EPersonaState.Online);
+  refreshWatchList();
+});
+
+client.on('loginKey', (key) => {
+  log('info', 'Received new login key');
+  loginKey = key;
+  if (loginKeyPath) {
+    try {
+      fs.writeFileSync(loginKeyPath, key, 'utf8');
+      log('info', 'Stored login key to file', { loginKeyPath });
+    } catch (err) {
+      log('warn', 'Failed to persist login key to file', { loginKeyPath, error: err.message });
+    }
+  }
+});
+
+client.on('steamGuard', (domain, callback, lastCodeWrong) => {
+  log('warn', 'Steam Guard required', { domain: domain || 'device', lastCodeWrong: Boolean(lastCodeWrong) });
+  if (totpSecret) {
+    const code = SteamTotp.generateAuthCode(totpSecret);
+    log('info', 'Supplying TOTP Steam Guard code');
+    callback(code);
+  } else if (guardCode) {
+    const code = guardCode;
+    guardCode = '';
+    log('info', 'Supplying static Steam Guard code');
+    callback(code);
+  } else {
+    log('error', 'No Steam Guard code available. Set STEAM_TOTP_SECRET or STEAM_GUARD_CODE.');
+  }
+});
+
+client.on('friendRichPresence', (steamID, appID) => {
+  const sid64 = steamID.getSteamID64();
+  const presence = client.getFriendRichPresence(steamID) || {};
+  const normalized = {};
+  for (const [key, value] of Object.entries(presence)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    normalized[key] = typeof value === 'string' ? value : String(value);
+  }
+
+  const entry = {
+    steam_id: sid64,
+    app_id: Number(appID) || null,
+    status: normalized.status || null,
+    display: normalized.steam_display || normalized.display || null,
+    player_group: normalized.steam_player_group || null,
+    player_group_size: normalized.steam_player_group_size ? Number(normalized.steam_player_group_size) || null : null,
+    connect: normalized.connect || null,
+    raw_json: JSON.stringify(normalized),
+    last_update: Math.floor(Date.now() / 1000),
+  };
+
+  try {
+    upsertPresence.run(entry);
+    log('debug', 'Stored rich presence update', { steamId: sid64, appId: entry.app_id, status: entry.status, display: entry.display });
+  } catch (err) {
+    log('error', 'Failed to persist rich presence', { steamId: sid64, error: err.message });
+  }
+});
+
+client.on('friendRelationship', (steamID, relationship) => {
+  if (relationship === SteamUser.EFriendRelationship.RequestRecipient) {
+    const sid64 = steamID.getSteamID64();
+    log('info', 'Accepting inbound friend request', { steamId: sid64 });
+    try {
+      client.addFriend(steamID);
+    } catch (err) {
+      log('warn', 'Failed to accept friend request', { steamId: sid64, error: err.message });
+      return;
+    }
+    const cached = watchList.get(sid64);
+    if (cached) {
+      safeRequestRichPresence(cached);
+    }
+    return;
+  }
+
+  if (relationship === SteamUser.EFriendRelationship.None) {
+    const sid64 = steamID.getSteamID64();
+    if (watchList.delete(sid64)) {
+      log('info', 'Friend relationship removed, deleting from watch list', { steamId: sid64 });
+    }
+  }
+});
+
+client.on('disconnected', (eresult, msg) => {
+  isLoggedOn = false;
+  log('warn', 'Steam disconnected', { eresult, msg });
+  scheduleReconnect();
+});
+
+client.on('error', (err) => {
+  log('error', 'Steam client error', { error: err.message });
+});
+
+client.on('webSession', () => {
+  log('debug', 'Web session established');
+});
+
+refreshWatchList();
+setInterval(refreshWatchList, WATCH_REFRESH_MS);
+setInterval(pollPresence, POLL_INTERVAL_MS);
+
+logOn();
+
+function shutdown() {
+  log('info', 'Shutting down presence service');
+  try {
+    client.logOff();
+  } catch (err) {
+    log('debug', 'logOff error', { error: err.message });
+  }
+  try {
+    db.close();
+  } catch (err) {
+    log('debug', 'DB close error', { error: err.message });
+  }
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('uncaughtException', (err) => {
+  log('error', 'Uncaught exception', { error: err.stack || err.message });
+  shutdown();
+});

--- a/service/steam_presence/package-lock.json
+++ b/service/steam_presence/package-lock.json
@@ -1,0 +1,1012 @@
+{
+  "name": "deadlock-steam-presence",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deadlock-steam-presence",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^9.4.0",
+        "dotenv": "^16.4.5",
+        "steam-totp": "^2.1.1",
+        "steam-user": "^5.0.0"
+      }
+    },
+    "node_modules/@bbob/parser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.9.0.tgz",
+      "integrity": "sha512-tldSYsMoEclke/B1nqL7+HbYMWZHTKvpbEHRSHuY+sZvS1o7Jpdfjb+KPpwP9wLI3p3r7GPv69/wGy+Xibs9yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bbob/plugin-helper": "^2.9.0"
+      }
+    },
+    "node_modules/@bbob/plugin-helper": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.9.0.tgz",
+      "integrity": "sha512-idpUcNQ2co6T1oU/7/DG/ZRfipSSkTn9Ozw9f5vaXH7nzV3qhqZnhFVlHTzGGnRlzKlBwWOBzOdWi4Zeqg1c5A==",
+      "license": "MIT"
+    },
+    "node_modules/@doctormckay/stdlib": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+      "integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+      "license": "MIT",
+      "dependencies": {
+        "psl": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@doctormckay/steam-crypto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
+      "integrity": "sha512-lsxgLw640gEdZBOXpVIcYWcYD+V+QbtEsMPzRvjmjz2XXKc7QeEMyHL07yOFRmay+cUwO4ObKTJO0dSInEuq5g==",
+      "license": "MIT"
+    },
+    "node_modules/@doctormckay/user-agents": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/user-agents/-/user-agents-1.0.0.tgz",
+      "integrity": "sha512-F+sL1YmebZTY2CnjoR9BXFEULpq7y8dxyLx48LZVa0BSDseXdLG/DtPISfM1iNv1XKCeiBzVNfAT/MOQ69v1Zw==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/binarykvparser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binarykvparser/-/binarykvparser-2.3.0.tgz",
+      "integrity": "sha512-B1N5ZxC8I9oSLis7Rg36DxsZJoIikUGU2XwpI0FKFCaPIJIEYi0B9UeIk3QU006axzq0TI9KC3iXelfGGgnWew==",
+      "bundleDependencies": [
+        "long"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "long": "^3.2.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha512-IuzSdmADppkZ6DlpycMkm8l9zeEq16fWtLvunEwFiYciR/BHo4E8/xs5piFquG+Za8OWmMqHF8zuRviz2LHvRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "~3"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.1.tgz",
+      "integrity": "sha512-y/K/1OCha04OXOxzo3cXJYtIzEk/CUMBb7Okipxueu0u+xCiuoocbwPyh1smUBasOobo4GAYmjgjD9Vh5zI51w==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/file-manager/node_modules/@doctormckay/stdlib": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.16.1.tgz",
+      "integrity": "sha512-XhuUOzElz6fnNdt70IYNKqhPAEpGaL4JHOhAvklRh0hAhVPW+/wLxaWT3DWUbaG5Dta5YvIp7+cZK3GhIpAuug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/kvparser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/kvparser/-/kvparser-1.0.2.tgz",
+      "integrity": "sha512-5P/5qpTAHjVYWqcI55B3yQwSY2FUrYYrJj5i65V1Wmg7/4W4OnBcaodaEvLyVuugeOnS+BAaKm9LbPazGJcRyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/lzma": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
+      "integrity": "sha512-DcfiawQ1avYbW+hsILhF38IKAlnguc/fjHrychs9hdxe4qLykvhT5VTGNs5YRWgaNePh7NTxGD4uv4gKsRomCQ==",
+      "license": "MIT",
+      "bin": {
+        "lzma.js": "bin/lzma.js"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-bignumber": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+      "integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/permessage-deflate": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
+      "integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/steam-appticket": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.2.tgz",
+      "integrity": "sha512-zwDwZALGv3RanE8RHNYcQU3u4Ez23EzMuQ4Lh15uIHddpDh6TI6uFGbC0HNyt6y+UJYSILe77A33VhFZKQiaqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^1.6.0",
+        "@doctormckay/steam-crypto": "^1.2.0",
+        "bytebuffer": "^5.0.1",
+        "protobufjs": "^6.8.8",
+        "steamid": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/@doctormckay/stdlib": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.16.1.tgz",
+      "integrity": "sha512-XhuUOzElz6fnNdt70IYNKqhPAEpGaL4JHOhAvklRh0hAhVPW+/wLxaWT3DWUbaG5Dta5YvIp7+cZK3GhIpAuug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/steam-appticket/node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/steamid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+      "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
+      "license": "MIT",
+      "dependencies": {
+        "cuint": "^0.2.1"
+      }
+    },
+    "node_modules/steam-session": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/steam-session/-/steam-session-1.9.4.tgz",
+      "integrity": "sha512-MLvg1uMLEOIRHZS5LKruy1w5OqHb8EL7TeMxIY2a4mUcaVOgszz060+jo4c7s3gFeedyuoqGcfwJrR0pLKYzLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^2.9.0",
+        "@doctormckay/user-agents": "^1.0.0",
+        "debug": "^4.3.4",
+        "kvparser": "^1.0.1",
+        "node-bignumber": "^1.2.2",
+        "protobufjs": "^7.1.0",
+        "socks-proxy-agent": "^7.0.0",
+        "steamid": "^2.0.0",
+        "tiny-typed-emitter": "^2.1.0",
+        "websocket13": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/steam-totp": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.2.tgz",
+      "integrity": "sha512-bTKlc/NoIUQId+my+O556s55DDsNNXfVIPWFDNVu68beql7AJhV0c+GTjFxfwCDYfdc4NkAme+0WrDdnY2D2VA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/steam-user": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-5.2.3.tgz",
+      "integrity": "sha512-6Yzaa0l7fcSRaaJzHjfuqettYqAsrW3+1AEu/cj4M/lgRYXa0DfOAjuWj0/wesfkogwuXNE4N/ZMZvNir8TVtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bbob/parser": "^2.2.0",
+        "@doctormckay/stdlib": "^2.9.1",
+        "@doctormckay/steam-crypto": "^1.2.0",
+        "adm-zip": "^0.5.10",
+        "binarykvparser": "^2.2.0",
+        "bytebuffer": "^5.0.0",
+        "file-manager": "^2.0.0",
+        "kvparser": "^1.0.1",
+        "lzma": "^2.3.2",
+        "protobufjs": "^7.2.4",
+        "socks-proxy-agent": "^7.0.0",
+        "steam-appticket": "^1.0.1",
+        "steam-session": "^1.8.0",
+        "steam-totp": "^2.0.1",
+        "steamid": "^2.0.0",
+        "websocket13": "^4.0.0",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/steamid": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+      "integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket13": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-4.0.0.tgz",
+      "integrity": "sha512-/ujP9ZfihyAZIXKGxcYpoe7Gj4r5o3WYSfP93o9lVNhhqoBtYba4m1s3mxdjKZu/HOhX5Mcqrt89dv/gC3b06A==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^2.7.1",
+        "bytebuffer": "^5.0.1",
+        "permessage-deflate": "^0.1.7",
+        "tiny-typed-emitter": "^2.1.0",
+        "websocket-extensions": "^0.1.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
+    }
+  }
+}

--- a/service/steam_presence/package.json
+++ b/service/steam_presence/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "deadlock-steam-presence",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Steam Rich Presence collector for the Deadlock Discord bots.",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.0",
+    "dotenv": "^16.4.5",
+    "steam-totp": "^2.1.1",
+    "steam-user": "^5.0.0"
+  }
+}

--- a/steam/README.md
+++ b/steam/README.md
@@ -1,0 +1,17 @@
+# Steam Service Helpers
+
+This folder contains the Python utilities that supervise the `service/steam_presence`
+Node.js worker.  The main entry point is `SteamPresenceServiceManager`, which is
+used by the master Discord bot to start, stop, and inspect the Steam rich presence
+bridge directly from Discord.
+
+The manager supports:
+
+- Automatic dependency installation (`npm install`) unless disabled with
+  `STEAM_SERVICE_AUTO_INSTALL=0`.
+- Boot-time auto start when `AUTO_START_STEAM_SERVICE` is truthy (default: on).
+- Crash monitoring with automatic restart.
+- Manual control through the `master steam ...` command group.
+
+See `service/steam_presence/README.md` for environment variables required by the
+Node.js worker.

--- a/steam/__init__.py
+++ b/steam/__init__.py
@@ -1,0 +1,5 @@
+"""Steam-related helpers for the Deadlock bot suite."""
+
+from .service_manager import SteamPresenceServiceManager
+
+__all__ = ["SteamPresenceServiceManager"]

--- a/steam/service_manager.py
+++ b/steam/service_manager.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Deque, List, Optional
+
+LOGGER = logging.getLogger("steam.presence")
+
+_FALSE_VALUES = {"0", "false", "no", "off", "disabled"}
+
+
+def _to_bool(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() not in _FALSE_VALUES
+
+
+@dataclass
+class SteamServiceStatus:
+    running: bool
+    pid: Optional[int]
+    returncode: Optional[int]
+    last_start: Optional[float]
+    last_exit: Optional[float]
+    restarts: int
+    cmd: str
+    cwd: Path
+    auto_start: bool
+
+
+class SteamPresenceServiceManager:
+    """Controls the node-based Steam rich presence bridge."""
+
+    def __init__(self, service_dir: Optional[Path] = None) -> None:
+        root = Path(__file__).resolve().parent.parent
+        self.service_dir = service_dir or root / "service" / "steam_presence"
+        self.start_command = os.getenv("STEAM_SERVICE_CMD", "npm run start")
+        self.install_command = os.getenv("STEAM_SERVICE_INSTALL_CMD", "npm install")
+        self.auto_start = _to_bool(os.getenv("AUTO_START_STEAM_SERVICE"), True)
+        self.auto_install = _to_bool(os.getenv("STEAM_SERVICE_AUTO_INSTALL"), True)
+        self.shutdown_timeout = float(os.getenv("STEAM_SERVICE_SHUTDOWN_TIMEOUT", "10"))
+        self.restart_on_crash = _to_bool(os.getenv("STEAM_SERVICE_RESTART_ON_CRASH"), True)
+
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._stdout_task: Optional[asyncio.Task[None]] = None
+        self._stderr_task: Optional[asyncio.Task[None]] = None
+        self._lock: Optional[asyncio.Lock] = None
+        self._stdout: Deque[str] = deque(maxlen=100)
+        self._stderr: Deque[str] = deque(maxlen=100)
+        self._last_start: Optional[float] = None
+        self._last_exit: Optional[float] = None
+        self._restart_count = 0
+        self._deps_checked = False
+        self._closing = False
+        self._monitor_task: Optional[asyncio.Task[None]] = None
+
+    async def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    async def ensure_dependencies(self) -> None:
+        if self._deps_checked:
+            return
+        self._deps_checked = True
+
+        package_json = self.service_dir / "package.json"
+        if not package_json.exists():
+            LOGGER.warning("Steam presence service directory %s missing package.json", self.service_dir)
+            return
+
+        node_modules = self.service_dir / "node_modules"
+        if node_modules.exists() and not _to_bool(os.getenv("STEAM_SERVICE_FORCE_INSTALL"), False):
+            return
+
+        cmd = self.install_command
+        LOGGER.info("Installing steam presence dependencies via '%s' (cwd=%s)", cmd, self.service_dir)
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            cwd=str(self.service_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout = []
+        if proc.stdout is not None:
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                text = line.decode(errors="replace").rstrip()
+                stdout.append(text)
+                LOGGER.debug("[npm install] %s", text)
+        rc = await proc.wait()
+        if rc != 0:
+            raise RuntimeError(f"npm install failed with exit code {rc}: {'; '.join(stdout[-10:])}")
+        LOGGER.info("npm dependencies ready")
+
+    async def ensure_started(self) -> bool:
+        lock = await self._get_lock()
+        async with lock:
+            if self.is_running:
+                return False
+
+            if self.auto_install:
+                await self.ensure_dependencies()
+
+            cmd = self.start_command
+            LOGGER.info("Starting steam presence service using '%s' (cwd=%s)", cmd, self.service_dir)
+            self._closing = False
+            self._process = await asyncio.create_subprocess_shell(
+                cmd,
+                cwd=str(self.service_dir),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            self._last_start = time.time()
+            self._stdout.clear()
+            self._stderr.clear()
+            if self._process.stdout is not None:
+                self._stdout_task = asyncio.create_task(self._pump_stream(self._process.stdout, self._stdout, logging.INFO, "stdout"))
+            if self._process.stderr is not None:
+                self._stderr_task = asyncio.create_task(self._pump_stream(self._process.stderr, self._stderr, logging.WARNING, "stderr"))
+            self._monitor_task = asyncio.create_task(self._monitor_process())
+            LOGGER.info("Steam presence service started (pid=%s)", self._process.pid)
+            return True
+
+    async def stop(self) -> bool:
+        lock = await self._get_lock()
+        async with lock:
+            if not self.is_running:
+                return False
+            assert self._process is not None
+            self._closing = True
+            proc = self._process
+            LOGGER.info("Stopping steam presence service (pid=%s)...", proc.pid)
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                LOGGER.debug("Process already gone when attempting terminate")
+            except Exception as exc:
+                LOGGER.warning("Failed to terminate steam presence service: %s", exc)
+
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=self.shutdown_timeout)
+            except asyncio.TimeoutError:
+                LOGGER.warning("Steam presence service did not exit in %.1fs, killing", self.shutdown_timeout)
+                proc.kill()
+                await proc.wait()
+
+            self._last_exit = time.time()
+            self._cleanup_tasks()
+            LOGGER.info("Steam presence service stopped with code %s", proc.returncode)
+            self._process = None
+            return True
+
+    async def restart(self) -> bool:
+        restarted = False
+        if self.is_running:
+            await self.stop()
+            restarted = True
+        await self.ensure_started()
+        self._restart_count += 1
+        return restarted
+
+    def _cleanup_tasks(self) -> None:
+        for task in (self._stdout_task, self._stderr_task, self._monitor_task):
+            if task is None:
+                continue
+            task.cancel()
+        self._stdout_task = None
+        self._stderr_task = None
+        self._monitor_task = None
+
+    async def _pump_stream(self, stream: asyncio.StreamReader, buffer: Deque[str], level: int, label: str) -> None:
+        try:
+            while True:
+                line = await stream.readline()
+                if not line:
+                    break
+                text = line.decode(errors="replace").rstrip()
+                buffer.append(text)
+                LOGGER.log(level, "[steam %s] %s", label, text)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            LOGGER.warning("Error while reading %s: %s", label, exc)
+
+    async def _monitor_process(self) -> None:
+        if self._process is None:
+            return
+        proc = self._process
+        try:
+            rc = await proc.wait()
+        except asyncio.CancelledError:
+            return
+        self._last_exit = time.time()
+        self._cleanup_tasks()
+        if self._closing:
+            LOGGER.info("Steam presence service exited with code %s", rc)
+            self._process = None
+            return
+        LOGGER.warning("Steam presence service exited unexpectedly with code %s", rc)
+        self._process = None
+        if self.restart_on_crash:
+            try:
+                await asyncio.sleep(2)
+                await self.ensure_started()
+                self._restart_count += 1
+            except Exception as exc:
+                LOGGER.error("Failed to restart steam presence service: %s", exc)
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.returncode is None
+
+    def tail(self, *, stderr: bool = False, limit: int = 20) -> List[str]:
+        buffer: Deque[str] = self._stderr if stderr else self._stdout
+        if limit <= 0:
+            return []
+        items = list(buffer)
+        slice_start = max(0, len(items) - limit)
+        return items[slice_start:]
+
+    def status(self) -> SteamServiceStatus:
+        pid = self._process.pid if self._process else None
+        returncode = self._process.returncode if self._process else None
+        return SteamServiceStatus(
+            running=self.is_running,
+            pid=pid,
+            returncode=returncode,
+            last_start=self._last_start,
+            last_exit=self._last_exit,
+            restarts=self._restart_count,
+            cmd=self.start_command,
+            cwd=self.service_dir,
+            auto_start=self.auto_start,
+        )


### PR DESCRIPTION
## Summary
- add a SteamPresenceServiceManager module and auto-start/stop the Node.js rich presence bridge from the master bot lifecycle
- expose owner-only `!master steam …` commands for status, start/stop/restart and log tailing while surfacing the service state in `!master status`
- document the new controller, configuration variables, and directory layout for the recreated `/steam` helper folder

## Testing
- python -m compileall main_bot.py steam/service_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b99e366c832fbe685c99ea09114a