### PR TITLE
Use steamid package for SteamID construction

### DIFF
--- a/service/steam_presence/index.js
+++ b/service/steam_presence/index.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const SteamUser = require('steam-user');
+const SteamID = require('steamid');
 const SteamTotp = require('steam-totp');
 const Database = require('better-sqlite3');
 
@@ -198,7 +199,7 @@ function refreshWatchList() {
     next.add(sid);
     if (!watchList.has(sid)) {
       try {
-        const steamID = new SteamUser.SteamID(sid);
+        const steamID = new SteamID(sid);
         watchList.set(sid, steamID);
         log('info', 'Added SteamID to watch list', { steamId: sid });
         if (isLoggedOn) {


### PR DESCRIPTION
## Summary
- import the steamid package in the Steam presence service
- construct SteamID instances using the steamid package rather than steam-user internals

## Testing
- npm run start *(fails: better-sqlite3 native bindings unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27f4afd74832fa4bd40416cd3dd56