### PR TITLE
Harden OAuth deeplink validation and fix presence helper

### DIFF
--- a/cogs/live_match/live_match_master.py
+++ b/cogs/live_match/live_match_master.py
@@ -274,6 +274,7 @@ class LiveMatchMaster(commands.Cog):
         sid = summary.get("gameserversteamid")
         return str(sid) if sid else None
 
+    @staticmethod
     def _presence_server_id(pres: dict) -> Optional[str]:
         raw = pres.get("raw") or {}
         group = pres.get("player_group") or raw.get("steam_player_group")

--- a/cogs/steam_link_voice_nudge.py
+++ b/cogs/steam_link_voice_nudge.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import asyncio
 import logging
-import inspect
 import re
 from typing import Optional, Dict, Union, Tuple
 from urllib.parse import urlparse, urlunparse
@@ -41,7 +40,15 @@ def _prefer_discord_deeplink(browser_url: Optional[str]) -> Tuple[Optional[str],
         return None, None
     try:
         u = urlparse(browser_url)
-        if "discord.com" in (u.netloc or "") and "/oauth2/authorize" in (u.path or "") and _DEEPLINK_EN:
+        hostname = (u.hostname or "").lower()
+        path = u.path or ""
+        if (
+            _DEEPLINK_EN
+            and u.scheme in {"http", "https"}
+            and hostname
+            and (hostname == "discord.com" or hostname.endswith(".discord.com"))
+            and (path == "/oauth2/authorize" or path.startswith("/oauth2/authorize/"))
+        ):
             deeplink = urlunparse(("discord", "-/oauth2/authorize", "", "", u.query, ""))
             return deeplink, browser_url
     except Exception:

--- a/cogs/twitch_deadlock/cog.py
+++ b/cogs/twitch_deadlock/cog.py
@@ -32,7 +32,7 @@ import asyncio
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 import discord
 from discord.ext import commands, tasks


### PR DESCRIPTION
## Summary
- tighten Discord OAuth deeplink validation in the steam linking flows and normalize manual Steam URLs before validation
- mark the presence server helper as static to avoid implicit self arguments and clean up unused imports
- drop an unused typing import from the Twitch Deadlock cog

## Testing
- python -m compileall cogs/welcome_dm/step_steam_link.py cogs/steam_link_voice_nudge.py cogs/live_match/live_match_master.py cogs/twitch_deadlock/cog.py

------
https://chatgpt.com/codex/tasks/task_e_68e28cdb7958832faf70a9dcb24ccc28