### PR TITLE
Improve steam nudge test command targeting

### DIFF
--- a/cogs/steam_link_voice_nudge.py
+++ b/cogs/steam_link_voice_nudge.py
@@ -483,10 +483,18 @@ class SteamLinkVoiceNudge(commands.Cog):
         except Exception:
             log.exception("wait_and_notify failed")
 
-    @commands.hybrid_command(name="nudgesend", description="(Admin) Schickt die Steam-Nudge-DM an einen Nutzer.")
+    @commands.hybrid_command(
+        name="nudgesend",
+        description="(Admin) Schickt die Steam-Nudge-DM an einen Nutzer.",
+        aliases=("t30",),
+    )
     @commands.has_permissions(administrator=True)
-    async def nudgesend(self, ctx: commands.Context, target: Optional[discord.Member] = None):
-        target = target or (ctx.guild.get_member(DEFAULT_TEST_TARGET_ID) if ctx.guild and DEFAULT_TEST_TARGET_ID else None)
+    async def nudgesend(
+        self,
+        ctx: commands.Context,
+        target: Optional[Union[discord.Member, discord.User]] = None,
+    ):
+        target = await self._resolve_test_target(ctx, target)
         if not target:
             await ctx.reply("Bitte Ziel angeben: `!nudgesend @user`", mention_author=False)
             return
@@ -500,6 +508,40 @@ class SteamLinkVoiceNudge(commands.Cog):
             await ctx.reply(f"📨 Test-DM an {getattr(target, 'mention', target.id)} gesendet.", mention_author=False)
         else:
             await ctx.reply("⚠️ Test-DM konnte nicht gesendet werden (DMs aus? oder bereits benachrichtigt).", mention_author=False)
+
+    async def _resolve_test_target(
+        self,
+        ctx: commands.Context,
+        target: Optional[Union[discord.Member, discord.User]],
+    ) -> Optional[Union[discord.Member, discord.User]]:
+        if target:
+            return target
+
+        if not DEFAULT_TEST_TARGET_ID:
+            return None
+
+        # Try resolve as guild member first.
+        guild = getattr(ctx, "guild", None)
+        if guild:
+            member = guild.get_member(DEFAULT_TEST_TARGET_ID)
+            if member:
+                return member
+            try:
+                member = await guild.fetch_member(DEFAULT_TEST_TARGET_ID)
+            except (discord.NotFound, discord.HTTPException, discord.Forbidden):
+                member = None
+            if member:
+                return member
+
+        # Fall back to any known user object in cache/API.
+        user = self.bot.get_user(DEFAULT_TEST_TARGET_ID)
+        if user:
+            return user
+
+        try:
+            return await self.bot.fetch_user(DEFAULT_TEST_TARGET_ID)
+        except (discord.NotFound, discord.HTTPException, discord.Forbidden):
+            return None
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
## Summary
- add a `t30` alias to the Steam voice nudge test command for quick access
- resolve the default test target via guild cache, guild fetch, or bot user fetch so the command works without a mention

## Testing
- python -m compileall cogs/steam_link_voice_nudge.py

------
https://chatgpt.com/codex/tasks/task_e_68e3759f2b74832fb5e7f0a9bd9d6e0d