### PR TITLE
Add Steam friend request queue and persist login key

### DIFF
--- a/cogs/rules_channel.py
+++ b/cogs/rules_channel.py
@@ -183,7 +183,8 @@ class RulesPanel(commands.Cog):
             desc=(
                 "Für Voice-Status & Features bitte deinen Steam-Account verknüpfen.\n"
                 "🤝 Wenn du dich via Discord oder Steam anmeldest, senden wir dir automatisch eine Freundschaftsanfrage. "
-                "Mehr Optionen findest du über **Freundschafts-Optionen** (Bot-ID 820142646, Schnell-Link usw.).\n"
+                "Mehr Optionen findest du über **Freundschafts-Optionen** (Schnell-Link <https://s.team/p/820142646> "
+                "oder Freundescode 820142646).\n"
                 "**Wichtig:** Steam → Profil → Spieldetails = Öffentlich."
             ),
             step=2,

--- a/cogs/steam_link_voice_nudge.py
+++ b/cogs/steam_link_voice_nudge.py
@@ -11,6 +11,7 @@ import discord
 from discord.ext import commands
 
 from service import db
+from service.steam_friend_requests import queue_friend_request
 
 log = logging.getLogger("SteamVoiceNudge")
 
@@ -69,6 +70,10 @@ def _save_steam_link_row(user_id: int, steam_id: str, name: str = "", verified: 
         """,
         (int(user_id), str(steam_id), name or "", int(verified)),
     )
+    try:
+        queue_friend_request(steam_id)
+    except Exception:
+        log.exception("[nudge] Konnte Steam-Freundschaftsanfrage nicht einreihen", extra={"steam_id": steam_id})
 
 def _ensure_schema():
     db.execute("""
@@ -418,7 +423,9 @@ class SteamLinkVoiceNudge(commands.Cog):
                 "• Ergebnis: präzisere **Kanal-Beschreibungen** (z. B. „3 im Match“) & bessere **Orga/Balancing** bei Events.\n\n"
                 "**Wie kannst du dabei helfen?**\n"
                 "1) Klicke **„Via Discord verknüpfen“**, **„SteamID manuell eingeben“** oder **„Mit Steam anmelden“**.\n"
-                "2) Folge den kurzen Schritten. Wir bekommen niemals dein Passwort – bei Steam erhalten wir nur die **SteamID64**.\n\n"
+                "2) Folge den kurzen Schritten. Wir bekommen niemals dein Passwort – bei Steam erhalten wir nur die **SteamID64**.\n"
+                "3) Der Steam-Bot schickt dir anschließend automatisch eine Freundschaftsanfrage. "
+                "Alternativ: <https://s.team/p/820142646> oder Freundescode **820142646**.\n\n"
                 "**Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** "
                 "(und **Gesamtspielzeit** nicht auf „immer privat“)."
             )

--- a/cogs/welcome_dm/step_steam_link.py
+++ b/cogs/welcome_dm/step_steam_link.py
@@ -78,11 +78,9 @@ def build_steam_intro_embed() -> discord.Embed:
             "• **SteamID manuell eingeben**: Du trägst **ID64 / Vanity / Profil-Link** selbst ein.\n"
             "• **Steam Profil suchen**: Offizieller Steam OpenID-Flow (kein Passwort, wir sehen nur die **SteamID64**).\n\n"
             "🤝 **Freundschaft mit dem Bot:** Sobald du dich via Discord oder Steam authentifizierst, "
-            "schickt dir unser Bot automatisch eine Anfrage. Alternativen findest du unter den "
-            "Freundschafts-Optionen:\n"
-            "  1️⃣ Du sendest selbst eine Anfrage an **820142646** (Bot-Account).\n"
-            "  2️⃣ Lass dir vom Bot eine Anfrage schicken – halte deinen **Freundescode** bereit.\n"
-            "  3️⃣ Nutze den Schnell-Link: <https://s.team/p/820142646>.\n\n"
+            "schickt dir unser Bot automatisch eine Anfrage. Alternativ kannst du manuell adden:\n"
+            "  🔗 Schnell-Link: <https://s.team/p/820142646>.\n"
+            "  🔢 Freundescode: **820142646** (oder gib ihn uns, dann senden wir dir eine Anfrage).\n\n"
             "**Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** "
             "(und **Gesamtspielzeit** nicht auf „immer privat“)."
         ),
@@ -266,10 +264,9 @@ class SteamLinkStepView(discord.ui.View):
         content = (
             "🤝 **So verbindest du dich mit unserem Steam-Bot:**\n"
             "• Sobald du dich über Discord oder Steam verknüpfst, senden wir dir automatisch eine Freundschaftsanfrage.\n\n"
-            "• Alternativen, falls du es manuell erledigen möchtest:\n"
-            "  1️⃣ Sende selbst eine Anfrage an **820142646** (Bot-Account).\n"
-            "  2️⃣ Lass dir vom Bot eine Anfrage schicken – halte deinen **Freundescode** bereit.\n"
-            "  3️⃣ Nutze den Schnell-Link: <https://s.team/p/820142646>."
+            "• Alternativ kannst du den Bot selbst hinzufügen:\n"
+            "  🔗 Schnell-Link: <https://s.team/p/820142646>.\n"
+            "  🔢 Freundescode: **820142646** (oder teile ihn uns mit, dann adden wir dich)."
         )
         if interaction.response.is_done():
             await interaction.followup.send(content, ephemeral=True)

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -6,6 +6,10 @@ try:
 except Exception:
     steam = None
 try:
+    from . import steam_friend_requests  # Queue für Steam-Freundschaftsanfragen
+except Exception:
+    steam_friend_requests = None
+try:
     from . import socket_bus  # falls vorhanden
 except Exception:
     socket_bus = None
@@ -14,4 +18,4 @@ try:
 except Exception:
     worker_client = None
 
-__all__ = ["db", "socket_bus", "worker_client", "steam"]
+__all__ = ["db", "socket_bus", "worker_client", "steam", "steam_friend_requests"]

--- a/service/db.py
+++ b/service/db.py
@@ -296,6 +296,16 @@ def init_schema(conn: Optional[sqlite3.Connection] = None) -> None:
               added_at INTEGER DEFAULT (strftime('%s','now'))
             );
 
+            -- Ausgehende Freundschaftsanfragen des Steam-Bots
+            CREATE TABLE IF NOT EXISTS steam_friend_requests(
+              steam_id TEXT PRIMARY KEY,
+              status TEXT DEFAULT 'pending',
+              requested_at INTEGER DEFAULT (strftime('%s','now')),
+              last_attempt INTEGER,
+              attempts INTEGER DEFAULT 0,
+              error TEXT
+            );
+
             -- Live-Lane-Status (pro Voice-Channel)
             CREATE TABLE IF NOT EXISTS live_lane_state(
               channel_id  INTEGER PRIMARY KEY,

--- a/service/steam_friend_requests.py
+++ b/service/steam_friend_requests.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from . import db
+
+log = logging.getLogger("SteamFriendRequests")
+
+
+_CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS steam_friend_requests(
+  steam_id TEXT PRIMARY KEY,
+  status TEXT DEFAULT 'pending',
+  requested_at INTEGER DEFAULT (strftime('%s','now')),
+  last_attempt INTEGER,
+  attempts INTEGER DEFAULT 0,
+  error TEXT
+)
+"""
+
+
+def _ensure_table() -> None:
+    try:
+        db.execute(_CREATE_SQL)
+    except Exception:
+        log.exception("Failed to ensure steam_friend_requests table exists")
+        raise
+
+
+def _queue_single(steam_id: str) -> None:
+    if not steam_id:
+        return
+    sid = str(steam_id).strip()
+    if not sid:
+        return
+    try:
+        db.execute(
+            """
+            INSERT INTO steam_friend_requests(steam_id, status)
+            VALUES(?, 'pending')
+            ON CONFLICT(steam_id) DO UPDATE SET
+              status=excluded.status,
+              last_attempt=NULL,
+              attempts=0,
+              error=NULL
+            WHERE steam_friend_requests.status != 'sent'
+            """,
+            (sid,),
+        )
+    except Exception:
+        log.exception("Failed to queue Steam friend request", extra={"steam_id": sid})
+
+
+def queue_friend_requests(steam_ids: Iterable[str]) -> None:
+    """Queue outgoing Steam friend requests for the given SteamIDs."""
+    if not steam_ids:
+        return
+    _ensure_table()
+    for steam_id in steam_ids:
+        _queue_single(steam_id)
+
+
+def queue_friend_request(steam_id: str) -> None:
+    """Queue a single outgoing Steam friend request."""
+    _ensure_table()
+    _queue_single(steam_id)
+
+
+__all__ = ["queue_friend_request", "queue_friend_requests"]

--- a/service/steam_presence/index.js
+++ b/service/steam_presence/index.js
@@ -15,14 +15,28 @@ const SteamID = require('steamid');
 const SteamTotp = require('steam-totp');
 const Database = require('better-sqlite3');
 
-const APP_ID = parseInt(process.env.DEADLOCK_APP_ID || '1422450', 10);
-const WATCH_REFRESH_MS = parseInt(process.env.RP_WATCH_REFRESH_SEC || '30', 10) * 1000;
-const POLL_INTERVAL_MS = parseInt(process.env.RP_POLL_INTERVAL_MS || '15000', 10);
 const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
 const LOG_LEVEL = (process.env.LOG_LEVEL || 'info').toLowerCase();
 const LOG_THRESHOLD = Object.prototype.hasOwnProperty.call(LOG_LEVELS, LOG_LEVEL)
   ? LOG_LEVELS[LOG_LEVEL]
   : LOG_LEVELS.info;
+
+function intOption(envName, fallback) {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === null || raw === '') {
+    return fallback;
+  }
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+const APP_ID = intOption('DEADLOCK_APP_ID', 1422450);
+const WATCH_REFRESH_MS = intOption('RP_WATCH_REFRESH_SEC', 30) * 1000;
+const POLL_INTERVAL_MS = intOption('RP_POLL_INTERVAL_MS', 15000);
+const FRIEND_REQUEST_INTERVAL_MS = Math.max(intOption('FRIEND_REQUEST_INTERVAL_MS', 15000), 1000);
+const FRIEND_REQUEST_RETRY_SEC = Math.max(intOption('FRIEND_REQUEST_RETRY_SEC', 300), 30);
+const FRIEND_REQUEST_BATCH_SIZE = Math.max(intOption('FRIEND_REQUEST_BATCH_SIZE', 20), 1);
+const FRIEND_REQUEST_MAX_ATTEMPTS = intOption('FRIEND_REQUEST_MAX_ATTEMPTS', 5);
 
 function log(level, message, extra = undefined) {
   const lvl = LOG_LEVELS[level];
@@ -54,9 +68,30 @@ function resolveDbPath() {
   return path.join(baseDir, 'deadlock.sqlite3');
 }
 
+function resolveLoginKeyPath(dbFilePath) {
+  if (process.env.STEAM_LOGIN_KEY_PATH) {
+    return path.resolve(process.env.STEAM_LOGIN_KEY_PATH);
+  }
+  const baseDir = process.env.STEAM_LOGIN_KEY_DIR
+    ? path.resolve(process.env.STEAM_LOGIN_KEY_DIR)
+    : (dbFilePath ? path.dirname(dbFilePath) : '');
+  if (!baseDir) {
+    return '';
+  }
+  return path.join(baseDir, 'steam_login.key');
+}
+
 const dbPath = resolveDbPath();
 log('info', 'Using SQLite database', { dbPath });
 const db = new Database(dbPath);
+
+const loginKeyPath = resolveLoginKeyPath(dbPath);
+if (loginKeyPath) {
+  log('info', 'Steam login key persistence enabled', {
+    loginKeyPath,
+    source: process.env.STEAM_LOGIN_KEY_PATH ? 'env' : 'default',
+  });
+}
 
 db.pragma('journal_mode = WAL');
 db.pragma('synchronous = NORMAL');
@@ -83,6 +118,17 @@ db.prepare(`
   )
 `).run();
 
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_friend_requests (
+    steam_id TEXT PRIMARY KEY,
+    status TEXT DEFAULT 'pending',
+    requested_at INTEGER DEFAULT (strftime('%s','now')),
+    last_attempt INTEGER,
+    attempts INTEGER DEFAULT 0,
+    error TEXT
+  )
+`).run();
+
 const upsertPresence = db.prepare(`
   INSERT INTO steam_rich_presence(steam_id, app_id, status, display, player_group, player_group_size, connect, raw_json, last_update)
   VALUES (@steam_id, @app_id, @status, @display, @player_group, @player_group_size, @connect, @raw_json, @last_update)
@@ -106,6 +152,40 @@ const watchlistQuery = db.prepare(`
   WHERE steam_id IS NOT NULL AND steam_id != ''
 `);
 
+let friendRequestQuerySql = `
+  SELECT steam_id, attempts FROM steam_friend_requests
+  WHERE status = 'pending'
+    AND (last_attempt IS NULL OR last_attempt <= strftime('%s','now') - ?)
+`;
+if (FRIEND_REQUEST_MAX_ATTEMPTS > 0) {
+  friendRequestQuerySql += ` AND attempts < ${FRIEND_REQUEST_MAX_ATTEMPTS}`;
+}
+friendRequestQuerySql += ' ORDER BY requested_at ASC LIMIT ?';
+const friendRequestQuery = db.prepare(friendRequestQuerySql);
+const markFriendRequestRetry = db.prepare(`
+  UPDATE steam_friend_requests
+  SET last_attempt = strftime('%s','now'),
+      attempts = attempts + 1,
+      error = @error
+  WHERE steam_id = @steam_id
+`);
+const markFriendRequestSent = db.prepare(`
+  UPDATE steam_friend_requests
+  SET status = 'sent',
+      last_attempt = strftime('%s','now'),
+      attempts = CASE WHEN attempts < 1 THEN 1 ELSE attempts END,
+      error = NULL
+  WHERE steam_id = @steam_id
+`);
+const markFriendRequestFailed = db.prepare(`
+  UPDATE steam_friend_requests
+  SET status = 'failed',
+      last_attempt = strftime('%s','now'),
+      attempts = attempts + 1,
+      error = @error
+  WHERE steam_id = @steam_id
+`);
+
 const client = new SteamUser();
 client.setOption('promptSteamGuardCode', false);
 
@@ -115,7 +195,6 @@ const watchList = new Map();
 
 const loginAccount = process.env.STEAM_BOT_USERNAME || process.env.STEAM_LOGIN || process.env.STEAM_ACCOUNT;
 let loginKey = process.env.STEAM_LOGIN_KEY || '';
-const loginKeyPath = process.env.STEAM_LOGIN_KEY_PATH ? path.resolve(process.env.STEAM_LOGIN_KEY_PATH) : '';
 const password = process.env.STEAM_BOT_PASSWORD || process.env.STEAM_PASSWORD;
 const totpSecret = process.env.STEAM_TOTP_SECRET || '';
 let guardCode = process.env.STEAM_GUARD_CODE || '';
@@ -232,11 +311,65 @@ function pollPresence() {
   }
 }
 
+function processFriendRequests() {
+  if (!isLoggedOn) {
+    return;
+  }
+  let rows = [];
+  try {
+    rows = friendRequestQuery.all(FRIEND_REQUEST_RETRY_SEC, FRIEND_REQUEST_BATCH_SIZE);
+  } catch (err) {
+    log('error', 'Failed to read pending friend requests', { error: err.message });
+    return;
+  }
+  if (!rows || rows.length === 0) {
+    return;
+  }
+
+  for (const row of rows) {
+    const sid = String(row.steam_id || '').trim();
+    if (!sid) {
+      continue;
+    }
+
+    let steamID;
+    try {
+      steamID = new SteamID(sid);
+    } catch (err) {
+      log('warn', 'Invalid SteamID in friend request queue', { steamId: sid, error: err.message });
+      try {
+        markFriendRequestFailed.run({ steam_id: sid, error: err.message });
+      } catch (dbErr) {
+        log('error', 'Failed to mark Steam friend request as failed', { steamId: sid, error: dbErr.message });
+      }
+      continue;
+    }
+
+    try {
+      log('info', 'Sending Steam friend request', { steamId: sid });
+      client.addFriend(steamID);
+      try {
+        markFriendRequestSent.run({ steam_id: sid });
+      } catch (dbErr) {
+        log('warn', 'Failed to persist friend request success state', { steamId: sid, error: dbErr.message });
+      }
+    } catch (err) {
+      log('warn', 'Steam friend request failed', { steamId: sid, error: err.message });
+      try {
+        markFriendRequestRetry.run({ steam_id: sid, error: err.message });
+      } catch (dbErr) {
+        log('error', 'Failed to persist friend request retry state', { steamId: sid, error: dbErr.message });
+      }
+    }
+  }
+}
+
 client.on('loggedOn', () => {
   isLoggedOn = true;
   log('info', 'Logged in to Steam', { account: loginAccount });
   client.setPersona(SteamUser.EPersonaState.Online);
   refreshWatchList();
+  processFriendRequests();
 });
 
 client.on('loginKey', (key) => {
@@ -244,6 +377,7 @@ client.on('loginKey', (key) => {
   loginKey = key;
   if (loginKeyPath) {
     try {
+      fs.mkdirSync(path.dirname(loginKeyPath), { recursive: true });
       fs.writeFileSync(loginKeyPath, key, 'utf8');
       log('info', 'Stored login key to file', { loginKeyPath });
     } catch (err) {
@@ -300,11 +434,20 @@ client.on('friendRichPresence', (steamID, appID) => {
 });
 
 client.on('friendRelationship', (steamID, relationship) => {
+  const sid64 = steamID.getSteamID64();
+
   if (relationship === SteamUser.EFriendRelationship.RequestRecipient) {
-    const sid64 = steamID.getSteamID64();
     log('info', 'Accepting inbound friend request', { steamId: sid64 });
     try {
       client.addFriend(steamID);
+      try {
+        markFriendRequestSent.run({ steam_id: sid64 });
+      } catch (dbErr) {
+        log('debug', 'Failed to update friend request state after accepting inbound request', {
+          steamId: sid64,
+          error: dbErr.message,
+        });
+      }
     } catch (err) {
       log('warn', 'Failed to accept friend request', { steamId: sid64, error: err.message });
       return;
@@ -316,8 +459,18 @@ client.on('friendRelationship', (steamID, relationship) => {
     return;
   }
 
+  if (relationship === SteamUser.EFriendRelationship.Friend) {
+    try {
+      markFriendRequestSent.run({ steam_id: sid64 });
+    } catch (err) {
+      log('debug', 'Failed to update friend request state for friend relationship', {
+        steamId: sid64,
+        error: err.message,
+      });
+    }
+  }
+
   if (relationship === SteamUser.EFriendRelationship.None) {
-    const sid64 = steamID.getSteamID64();
     if (watchList.delete(sid64)) {
       log('info', 'Friend relationship removed, deleting from watch list', { steamId: sid64 });
     }
@@ -341,6 +494,7 @@ client.on('webSession', () => {
 refreshWatchList();
 setInterval(refreshWatchList, WATCH_REFRESH_MS);
 setInterval(pollPresence, POLL_INTERVAL_MS);
+setInterval(processFriendRequests, FRIEND_REQUEST_INTERVAL_MS);
 
 logOn();
 


### PR DESCRIPTION
## Summary
- add a shared helper for queuing Steam friend requests and expose it via the service package
- persist the Steam login key by default and have the presence service process queued friend requests while updating relationship events
- enqueue Steam friend requests from the linking cogs and refresh the messaging about manual friend options

## Testing
- node --check service/steam_presence/index.js
- python -m compileall cogs/live_match/steam_link_oauth.py cogs/steam_link_voice_nudge.py cogs/welcome_dm/step_steam_link.py cogs/rules_channel.py service/steam_friend_requests.py


------
https://chatgpt.com/codex/tasks/task_e_68e38c113a48832fb7aae6447997c52c