### PR TITLE
Centralize Steam link descriptions

### DIFF
--- a/cogs/rules_channel.py
+++ b/cogs/rules_channel.py
@@ -25,7 +25,7 @@ log = logging.getLogger("RulesPanel")
 from cogs.welcome_dm.base import build_step_embed
 from cogs.welcome_dm.step_intro import IntroView
 from cogs.welcome_dm.step_status import PlayerStatusView
-from cogs.welcome_dm.step_steam_link import SteamLinkStepView
+from cogs.welcome_dm.step_steam_link import SteamLinkStepView, steam_link_detailed_description
 from cogs.welcome_dm.step_rules import RulesView
 
 
@@ -180,20 +180,7 @@ class RulesPanel(commands.Cog):
         # 2/3 Steam
         emb = build_step_embed(
             title="Frage 2/3 · Steam verknüpfen (empfohlen)",
-            desc=(
-            "• Wozu ist das gut? Wir können deinen **Spiel-Status** \n"
-            "(z. B. *Lobby/In-Game*, **Anzahl im Match**) als Status für den Sprach Kanel nehmen"
-            "Dadurch können wir präziser anzeigen wie der Status ist und Events sauberer balancen.\n\n"
-            "**Ablauf & Optionen:**\n"
-            "• **Via Discord verknüpfen** - Schnellster Weg.\n"
-            "• **SteamID manuell eingeben**: Du trägst **ID64 / Vanity / Profil-Link** selbst ein.\n"
-            "• **Steam Profil suchen**: Offizieller Steam OpenID-Flow (kein Passwort, wir sehen nur die **SteamID64**).\n\n"
-            "• Sobald du dich via Discord oder Steam authentifizierst, "
-            "schickt dir unser Bot automatisch eine Anfrage. Alternativ kannst du diesen manuell adden:\n"
-            "  ⚡ Über den Button **„Schnelle Anfrage senden“** erhältst du einen persönlichen Link.\n"
-            "  🔢 Freundescode: **820142646** oder schick dem Bot eine Freundschaftsanfrage über die ID\n\n"
-            "**Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** sonst funktioniert das nicht."
-            ),
+            desc=steam_link_detailed_description(),
             step=2,
             total=total,
             color=0x2ECC71,

--- a/cogs/steam_link_voice_nudge.py
+++ b/cogs/steam_link_voice_nudge.py
@@ -19,6 +19,8 @@ from cogs.steam import (
     queue_friend_request,
     respond_with_quick_invite,
 )
+from cogs.welcome_dm.step_steam_link import steam_link_detailed_description
+
 
 log = logging.getLogger("SteamVoiceNudge")
 
@@ -433,20 +435,7 @@ class SteamLinkVoiceNudge(commands.Cog):
             discord_url, steam_url = await _fetch_oauth_urls(self.bot, user)
             primary_discord, browser_fallback = _prefer_discord_deeplink(discord_url)
 
-            desc = (
-            "• Wozu ist das gut? Wir können deinen **Spiel-Status** \n"
-            "(z. B. *Lobby/In-Game*, **Anzahl im Match**) als Status für den Sprach Kanel nehmen"
-            "Dadurch können wir präziser anzeigen wie der Status ist und Events sauberer balancen.\n\n"
-            "**Ablauf & Optionen:**\n"
-            "• **Via Discord verknüpfen** - Schnellster Weg.\n"
-            "• **SteamID manuell eingeben**: Du trägst **ID64 / Vanity / Profil-Link** selbst ein.\n"
-            "• **Steam Profil suchen**: Offizieller Steam OpenID-Flow (kein Passwort, wir sehen nur die **SteamID64**).\n\n"
-            "• Sobald du dich via Discord oder Steam authentifizierst, "
-            "schickt dir unser Bot automatisch eine Anfrage. Alternativ kannst du diesen manuell adden:\n"
-            "  ⚡ Über den Button **„Schnelle Anfrage senden“** erhältst du einen persönlichen Link.\n"
-            "  🔢 Freundescode: **820142646** oder schick dem Bot eine Freundschaftsanfrage über die ID\n\n"
-            "**Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** sonst funktioniert das nicht."
-            )
+            desc = steam_link_detailed_description()
             if browser_fallback and (primary_discord or "").startswith("discord://"):
                 desc += f"\n\n_Falls sich nichts öffnet:_ [Browser-Variante]({browser_fallback})"
             if not primary_discord or not steam_url:

--- a/cogs/welcome_dm/dm_main.py
+++ b/cogs/welcome_dm/dm_main.py
@@ -16,7 +16,7 @@ from .base import (
 from .step_intro import IntroView
     # Intro info/weiter Button (nicht persistent registrieren)
 from .step_status import PlayerStatusView
-from .step_steam_link import SteamLinkStepView
+from .step_steam_link import SteamLinkStepView, steam_link_dm_description
 from .step_rules import RulesView
 from .step_streamer import StreamerIntroView  # Optionaler Schritt
 
@@ -156,13 +156,7 @@ class WelcomeDM(commands.Cog):
                 status_choice = status_view.choice or STATUS_PLAYING
 
                 # 2/3 Steam
-                q2_desc = (
-                    "**Empfohlen für das beste Erlebnis:**\n"
-                    "• Exakter **Voice-Status** (Lobby/Match, freie Slots)\n"
-                    "• Saubere **Event-Orga & Balancing**\n\n"
-                    "**Wichtig:** In Steam → Profil → **Privatsphäre** → "
-                    "**Spieldetails = Öffentlich** (und **Gesamtspielzeit** nicht auf „immer privat“)."
-                )
+                q2_desc = steam_link_dm_description()
                 if not await self._send_step_embed_dm(
                     member,
                     title="Frage 2/3 · Verknüpfe deinen Steam Account",
@@ -280,13 +274,7 @@ class WelcomeDM(commands.Cog):
             status_choice = status_view.choice or STATUS_PLAYING
 
             # 2/3 Steam
-            q2_desc = (
-                "**Empfohlen:** Exakter **Voice-Status**, saubere **Event-Orga & Balancing**.\n\n"
-                "🤝 **Freundschaft mit dem Bot:** Wenn du dich via Discord oder Steam verknüpfst, senden wir dir automatisch eine "
-                "Freundschaftsanfrage. Alternativen findest du über den Button **Freundschafts-Optionen** (z. B. Bot-ID 820142646 "
-                "oder der Schnell-Link).\n\n"
-                "**Wichtig:** Steam → Profil → **Spieldetails = Öffentlich** (Gesamtspielzeit nicht „immer privat“)."
-            )
+            q2_desc = steam_link_dm_description()
             ok = await self._send_step_embed_channel(
                 channel,
                 title="Frage 2/3 · Steam verknüpfen (skippbar)",

--- a/cogs/welcome_dm/step_steam_link.py
+++ b/cogs/welcome_dm/step_steam_link.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from textwrap import dedent
 from typing import Optional, Tuple
 from urllib.parse import urlparse, urlsplit, urlunparse, urlunsplit
 
@@ -14,6 +15,8 @@ __all__ = [
     "SteamLinkView",          # Alias (Backcompat)
     "SteamLinkNudgeView",     # Alias (für rules_channel)
     "build_steam_intro_embed",
+    "steam_link_dm_description",
+    "steam_link_detailed_description",
 ]
 
 # --- harte Abhängigkeit auf das OAuth/Link-Modul (keine Fallbacks) ---
@@ -68,24 +71,56 @@ STEAM_KEY_RE = re.compile(
 )
 
 
+_STEAM_LINK_DM_DESC = dedent(
+    """
+    **Empfohlen:** Exakter **Voice-Status**, saubere **Event-Orga & Balancing**.
+
+
+    🤝 **Freundschaft mit dem Bot:** Wenn du dich via Discord oder Steam verknüpfst, senden wir dir automatisch eine Freundschaftsanfrage. Alternativen findest du über den Button **Freundschafts-Optionen** (z. B. Bot-ID 820142646 oder der Schnell-Link).
+
+
+    **Wichtig:** Steam → Profil → **Spieldetails = Öffentlich** (Gesamtspielzeit nicht „immer privat“).
+    """
+).strip()
+
+
+_STEAM_LINK_DETAILED_DESC = dedent(
+    """
+    • Wozu ist das gut? Wir können deinen **Spiel-Status**
+      (z. B. *Lobby/In-Game*, **Anzahl im Match**) als Status für den Sprach Kanel nehmen.
+      Dadurch können wir präziser anzeigen wie der Status ist und Events sauberer balancen.
+
+
+    **Ablauf & Optionen:**
+    • **Via Discord verknüpfen** – Schnellster Weg.
+    • **SteamID manuell eingeben**: Du trägst **ID64 / Vanity / Profil-Link** selbst ein.
+    • **Steam Profil suchen**: Offizieller Steam OpenID-Flow (kein Passwort, wir sehen nur die **SteamID64**).
+
+
+    • Sobald du dich via Discord oder Steam authentifizierst, schickt dir unser Bot automatisch eine Anfrage.
+      Alternativ kannst du diesen manuell adden:
+      ⚡ Über den Button **„Schnelle Anfrage senden“** erhältst du einen persönlichen Link.
+      🔢 Freundescode: **820142646** oder schick dem Bot eine Freundschaftsanfrage über die ID
+
+
+    **Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** sonst funktioniert das nicht.
+    """
+).strip()
+
+
+def steam_link_dm_description() -> str:
+    return _STEAM_LINK_DM_DESC
+
+
+def steam_link_detailed_description() -> str:
+    return _STEAM_LINK_DETAILED_DESC
+
+
 def build_steam_intro_embed() -> discord.Embed:
     """Intro/Erklärung für den Schritt – mit Hinweis auf 'SteamID manuell'."""
     em = discord.Embed(
         title="Empfehlung für besseres Erlebnis",
-        description=(
-            "• Wozu ist das gut? Wir können deinen **Spiel-Status** \n"
-            "(z. B. *Lobby/In-Game*, **Anzahl im Match**) als Status für den Sprach Kanel nehmen"
-            "Dadurch können wir präziser anzeigen wie der Status ist und Events sauberer balancen.\n\n"
-            "**Ablauf & Optionen:**\n"
-            "• **Via Discord verknüpfen** - Schnellster Weg.\n"
-            "• **SteamID manuell eingeben**: Du trägst **ID64 / Vanity / Profil-Link** selbst ein.\n"
-            "• **Steam Profil suchen**: Offizieller Steam OpenID-Flow (kein Passwort, wir sehen nur die **SteamID64**).\n\n"
-            "• Sobald du dich via Discord oder Steam authentifizierst, "
-            "schickt dir unser Bot automatisch eine Anfrage. Alternativ kannst du diesen manuell adden:\n"
-            "  ⚡ Über den Button **„Schnelle Anfrage senden“** erhältst du einen persönlichen Link.\n"
-            "  🔢 Freundescode: **820142646** oder schick dem Bot eine Freundschaftsanfrage über die ID\n\n"
-            "**Wichtig:** In Steam → Profil → **Datenschutzeinstellungen** → **Spieldetails = Öffentlich** sonst funktioniert das nicht."
-        ),
+        description=steam_link_detailed_description(),
         colour=discord.Colour.blurple(),
     )
     em.set_footer(text="Kurzbefehle: /link, /link_steam, /addsteam")


### PR DESCRIPTION
## Summary
- add shared helper functions for Steam link onboarding copy in `step_steam_link`
- reuse the new helpers from the welcome DM, rules panel, and voice nudge flows so the text only lives in one place
- update the voice nudge embed to import the shared text helper

## Testing
- python -m compileall cogs/welcome_dm/step_steam_link.py cogs/welcome_dm/dm_main.py cogs/rules_channel.py cogs/steam_link_voice_nudge.py

------
https://chatgpt.com/codex/tasks/task_e_68e6c96021f8832f9fa27a5233643c89