### PR TITLE
Replace Twitch link scraping with manual verification controls

### DIFF
--- a/cogs/twitch/storage.py
+++ b/cogs/twitch/storage.py
@@ -81,6 +81,9 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             last_link_ok           INTEGER DEFAULT 0,
             last_link_checked_at   TEXT,
             next_link_check_at     TEXT,
+            manual_verified_permanent INTEGER DEFAULT 0,
+            manual_verified_until  TEXT,
+            manual_verified_at     TEXT,
             created_at             TEXT DEFAULT CURRENT_TIMESTAMP
         )
         """
@@ -93,6 +96,9 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         ("last_link_ok", "INTEGER DEFAULT 0"),
         ("last_link_checked_at", "TEXT"),
         ("next_link_check_at", "TEXT"),
+        ("manual_verified_permanent", "INTEGER DEFAULT 0"),
+        ("manual_verified_until", "TEXT"),
+        ("manual_verified_at", "TEXT"),
         ("created_at", "TEXT DEFAULT CURRENT_TIMESTAMP"),
     ]:
         _add_column_if_missing(conn, "twitch_streamers", col, spec)


### PR DESCRIPTION
## Summary
- remove the automated Discord link scraping and rescan flow from the Twitch admin dashboard
- add database fields plus dashboard controls to manually flag streamers as permanently verified or verified for 30 days with visible countdowns
- require manual verification before posting for streamers marked as needing checks, keeping stats and exports intact

## Testing
- python -m compileall cogs/twitch

------
https://chatgpt.com/codex/tasks/task_e_68eae7dd9200832f8b08a3a01ef00737