### PR TITLE
Fix LiveMatchWorker row handling for channel renames

### DIFF
--- a/cogs/live_match/live_match_worker.py
+++ b/cogs/live_match/live_match_worker.py
@@ -115,10 +115,11 @@ class LiveMatchWorker(commands.Cog):
 
         for r in rows:
             try:
-                channel_id = int(r["channel_id"])
-                desired_suffix_raw = (r["suffix"] or "").strip()
-                is_active = int(r["is_active"] or 0)
-                last_update = int(r.get("last_update") or 0)
+                row = dict(r)
+                channel_id = int(row["channel_id"])
+                desired_suffix_raw = (row.get("suffix") or "").strip()
+                is_active = int(row.get("is_active") or 0)
+                last_update = int(row.get("last_update") or 0)
             except Exception as e:
                 msg = f"Ungültiger Datensatz in live_lane_state: {e!r}"
                 log.debug(msg)


### PR DESCRIPTION
## Summary
- convert SQLite rows to dictionaries before accessing optional columns in the live match worker
- ensure the worker reads the last_update timestamp correctly so rename telemetry no longer aborts early

## Testing
- python -m compileall cogs/live_match/live_match_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68eb8fdd6f74832f918b2fd8bd34016b