### PR TITLE
Move Steam link OAuth cog into steam package

### DIFF
--- a/cogs/live_match/Setup Steam.md
+++ b/cogs/live_match/Setup Steam.md
@@ -407,7 +407,7 @@ C:\caddy\
 
 C:\apps\deadlock\
   main.py
-  cogs\live_match\steam_link_oauth.py
+  cogs\steam\steam_link_oauth.py
   # optional (Watchdog):
   cogs\caddy_watchdog.py
   shared\db.py

--- a/cogs/steam/steam_link_oauth.py
+++ b/cogs/steam/steam_link_oauth.py
@@ -1,4 +1,4 @@
-# cogs/live_match/steam_link_oauth.py
+# cogs/steam/steam_link_oauth.py
 import os
 import re
 import time

--- a/cogs/welcome_dm/step_steam_link.py
+++ b/cogs/welcome_dm/step_steam_link.py
@@ -23,14 +23,14 @@ __all__ = [
 # --- optionale Steam-Link-Integration (kann fehlen) ---
 _LOGGER = logging.getLogger(__name__)
 try:
-    from cogs.live_match import steam_link_oauth as _oauth  # type: ignore
+    from cogs.steam import steam_link_oauth as _oauth  # type: ignore
 except Exception:
     _oauth = None  # type: ignore[assignment]
     _LOGGER.info("Steam link OAuth module unavailable – link buttons will be disabled.")
 
 if _oauth is not None and not hasattr(_oauth, "start_urls_for"):
     _LOGGER.warning(
-        "cogs.live_match.steam_link_oauth is missing 'start_urls_for'; disabling Steam link buttons.",
+        "cogs.steam.steam_link_oauth is missing 'start_urls_for'; disabling Steam link buttons.",
     )
     _oauth = None  # type: ignore[assignment]
 


### PR DESCRIPTION
## Summary
- move the Steam link OAuth cog into the `cogs/steam` package and update its header comment
- point the welcome DM Steam step to the new module path
- refresh the setup documentation to reference the relocated cog

## Testing
- python -m compileall cogs/steam/steam_link_oauth.py cogs/welcome_dm/step_steam_link.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3dee09c4832f8645625cd60e373e