### PR TITLE
Cache Twitch previews as Discord attachments

### DIFF
--- a/cogs/twitch/twitch_api.py
+++ b/cogs/twitch/twitch_api.py
@@ -36,6 +36,12 @@ class TwitchAPI:
             self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15))
             self._own_session = True
 
+    def get_http_session(self) -> aiohttp.ClientSession:
+        """Return the internal aiohttp session, ensuring it exists."""
+        self._ensure_session()
+        assert self._session is not None
+        return self._session
+
     async def aclose(self) -> None:
         if self._own_session and self._session and not self._session.closed:
             await self._session.close()


### PR DESCRIPTION
## Summary
- download Twitch preview images during go-live posts and attach them to Discord messages to keep thumbnails stable
- fall back to cached URL with a timestamp query parameter if the download fails
- expose the Twitch API HTTP session for reuse by the cog when fetching previews

## Testing
- python -m compileall cogs/twitch/cog.py cogs/twitch/twitch_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f03a8d4a68832f846bb6f86364245b