### PR TITLE
Limit Steam master to hub mode and document presence bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ cogs/steam/steam_presence/*
 !cogs/steam/steam_presence/package.json
 !cogs/steam/steam_presence/package-lock.json
 !cogs/steam/steam_presence/index.js
+!cogs/steam/steam_presence/README.md
 
 *.db-shm
 *.db-wal

--- a/cogs/steam/steam_master.py
+++ b/cogs/steam/steam_master.py
@@ -1,380 +1,190 @@
-# filename: cogs/steam/steam_master.py
-"""Steam login manager cog for the master bot.
+"""Steam hub cog.
 
-Funktion:
-- Startet einen Hintergrund-Thread, der eine persistente Steam-Session hält.
-- Login-Strategie: login_key -> (sonst) Passwort -> (falls verlangt) 2FA via !sg CODE.
-- Persistiert login_key und Sentry/Machine-Auth im Datenverzeichnis.
-- Befehle: !sg, !steam_status, !steam_token, !steam_token_clear
+This cog intentionally no longer handles Steam logins itself.  The Node.js
+bridge located in :mod:`cogs.steam.steam_presence` is responsible for the
+real-time Rich Presence connection.  The cog merely surfaces shared state and
+housekeeping helpers so other Python modules can interact with the database and
+stored tokens in a consistent way.
 """
 
 from __future__ import annotations
 
+import enum
 import logging
 import os
-import threading
+from collections import defaultdict
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
-import discord
 from discord.ext import commands
 
-from steam.client import SteamClient
-from steam.enums import EResult
-from steam.enums.emsg import EMsg
+from service import db
 
 log = logging.getLogger(__name__)
 
 
-def _data_dir() -> Path:
-    """Resolve the data directory used to persist Steam auth artefacts."""
-    base = (os.getenv("STEAM_MASTER_DATA_DIR") or ".steam-data").strip() or ".steam-data"
-    path = Path(base)
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+class SteamMasterMode(enum.Enum):
+    """Operational mode for the hub cog."""
+
+    HUB = "hub"
+    DISABLED = "disabled"
 
 
-class SteamLoginManager(threading.Thread):
-    """Background thread that manages a persistent Steam session (no presence here)."""
+def _presence_data_dir() -> Path:
+    """Resolve the Node.js presence bridge data directory."""
 
-    def __init__(self, username: str, password: str, data_dir: Path):
-        super().__init__(daemon=True)
-        self.username = username
-        self.password = password
-        self.data_dir = data_dir
-        self.login_key_file = self.data_dir / "login_key.txt"
-        self.sentry_file = self.data_dir / "sentry.bin"
+    configured = (os.getenv("STEAM_PRESENCE_DATA_DIR") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
 
-        self.client = SteamClient()
-        # Leite Steam dazu an, Anmeldedaten/Sentry in unserem Ordner zu persistieren
-        try:
-            self.client.set_credential_location(str(self.data_dir))
-        except Exception:
-            # ältere/andere Builds haben die Methode evtl. nicht – ist ok
-            pass
+    return Path(__file__).resolve().parent / "steam_presence" / ".steam-data"
 
-        self.guard_code: Optional[str] = None
-        self._lock = threading.Lock()
-        self._stop_event = threading.Event()
 
-        self.logged_on = False
-        self.last_result: Optional[EResult] = None
+def _refresh_token_path() -> Path:
+    return _presence_data_dir() / "refresh.token"
 
-        # Steam event wiring
-        self.client.on(EMsg.ClientUpdateMachineAuth, self._on_machine_auth)
-        self.client.on(EMsg.ClientLogOnResponse, self._on_logon_response)
-        self.client.on(EMsg.ClientLoggedOff, self._on_logged_off)
 
-        # Greenlet-Runner für den Steam IO-Loop
-        self._io_runner = None
+def _machine_auth_path() -> Path:
+    return _presence_data_dir() / "machine_auth_token.txt"
 
-    # ---------- public API (used by Cog commands) ----------
-    def set_guard_code(self, code: str) -> None:
-        sanitized = code.strip()
-        with self._lock:
-            self.guard_code = sanitized
-        log.info("Steam Guard-Code übernommen (len=%s). Login wird erneut versucht.", len(sanitized))
 
-    def status(self) -> str:
-        has_key = self.login_key_file.exists() and self.login_key_file.stat().st_size > 0
-        has_sentry = self.sentry_file.exists() and self.sentry_file.stat().st_size > 0
-        return (
-            "logged_on={logged} last_result={result} login_key={key} sentry={sentry}".format(
-                logged=self.logged_on,
-                result=self.last_result,
-                key="yes" if has_key else "no",
-                sentry="yes" if has_sentry else "no",
-            )
-        )
+def _determine_mode() -> SteamMasterMode:
+    """Determine whether the hub should be active."""
 
-    def clear_login_key(self) -> bool:
-        try:
-            if self.login_key_file.exists():
-                self.login_key_file.unlink()
-                return True
-            return False
-        except Exception:
-            log.exception("Konnte login_key nicht löschen")
-            return False
+    raw = (os.getenv("STEAM_MASTER_MODE") or "hub").strip().lower()
+    if raw in {"disabled", "off", "none"}:
+        return SteamMasterMode.DISABLED
+    return SteamMasterMode.HUB
 
-    # ---------- persistence helpers ----------
-    def _read_login_key(self) -> Optional[str]:
-        try:
-            if self.login_key_file.exists():
-                key = self.login_key_file.read_text(encoding="utf-8").strip()
-                if key:
-                    log.debug("login_key gelesen (len=%s)", len(key))
-                else:
-                    log.debug("login_key-Datei vorhanden, aber leer")
-                return key or None
-            log.debug("login_key-Datei %s existiert nicht", self.login_key_file)
-        except Exception:
-            log.exception("Konnte login_key nicht lesen")
-        return None
 
-    def _write_login_key(self, key: str) -> None:
-        try:
-            self.login_key_file.write_text(key, encoding="utf-8")
-            log.info("Steam login_key gespeichert (%s)", self.login_key_file)
-        except Exception:
-            log.exception("Konnte login_key nicht speichern")
-
-    def _write_sentry(self, data: bytes) -> None:
-        try:
-            self.sentry_file.write_bytes(data)
-            log.info("Steam Sentry gespeichert (%s)", self.sentry_file)
-        except Exception:
-            log.exception("Konnte Sentry nicht speichern")
-
-    # ---------- steam event handlers ----------
-    def _on_machine_auth(self, msg) -> None:
-        data = getattr(msg.body, "bytes", b"")
-        if data:
-            log.debug(
-                "MachineAuth erhalten (offset=%s, sha1=%s)",
-                getattr(msg.body, "offset", "?"),
-                getattr(msg.body, "sha_file", "?"),
-            )
-            self._write_sentry(data)
-        else:
-            log.debug("MachineAuth Event ohne Daten erhalten: %s", msg.body)
-
-    def _on_logon_response(self, msg) -> None:
-        self.last_result = msg.body.eresult
-        log.debug(
-            "LogOnResponse erhalten: eresult=%s, extended=%s",
-            self.last_result,
-            getattr(msg.body, "eresult_extended", None),
-        )
-        if self.last_result == EResult.OK:
-            self.logged_on = True
-            key = getattr(self.client, "login_key", None)
-            if key:
-                self._write_login_key(str(key))
-            user = getattr(self.client.user, "name", "<unknown>")
-            log.info("Steam eingeloggt als %s", user)
-        else:
-            self.logged_on = False
-            log.warning(
-                "Steam LogOnResponse: %s (eresult_extended=%s, msg=%s)",
-                self.last_result,
-                getattr(msg.body, "eresult_extended", None),
-                getattr(msg.body, "error_message", None),
-            )
-
-    def _on_logged_off(self, msg) -> None:
-        self.logged_on = False
-        result = getattr(getattr(msg, "body", None), "eresult", None)
-        log.warning(
-            "Steam Logged off: %s (client_connected=%s)",
-            result,
-            getattr(self.client, "connected", None),
-        )
-
-    # ---------- login loop ----------
-    def _try_login(self) -> EResult:
-        log.debug("Login-Versuch gestartet. logged_on=%s", self.logged_on)
-
-        if not self.username:
-            log.error("STEAM_USERNAME ist nicht gesetzt. Abbruch.")
-            return EResult.InvalidParam
-
-        # 1) bevorzugt: login_key
-        login_key = self._read_login_key()
-        if login_key:
-            log.info("Steam-Login mit login_key ...")
-            log.debug("Login-Parameter: username=%s (login_key len=%s)", self.username, len(login_key))
-            return self.client.login(username=self.username, login_key=login_key)
-
-        # 2) Passwort (+ optional 2FA, wenn via !sg gesetzt)
-        with self._lock:
-            code = self.guard_code
-            self.guard_code = None
-
-        log.debug(
-            "Guard-Code %s gefunden und %s.",
-            "wurde" if code else "wurde nicht",
-            "verbraucht" if code else "nicht benötigt",
-        )
-
-        if code:
-            log.info("Steam-Login mit Passwort + 2FA ...")
-            log.debug(
-                "Login-Parameter: username=%s, two_factor_code_len=%s",
-                self.username,
-                len(code),
-            )
-            return self.client.login(
-                username=self.username,
-                password=self.password,
-                two_factor_code=code,
-            )
-
-        log.info("Steam-Login mit Passwort (ohne 2FA) ...")
-        log.debug("Login-Parameter: username=%s", self.username)
-        return self.client.login(username=self.username, password=self.password)
-
-    def run(self) -> None:
-        import gevent  # lokal im Thread ok
-
-        # Start IO-Loop als Greenlet, damit der gevent-Hub "lebt"
-        if self._io_runner is None:
-            self._io_runner = gevent.spawn(self.client.run_forever)
-
-        try:
-            while not self._stop_event.is_set():
-                try:
-                    with self._lock:
-                        has_guard = bool(self.guard_code)
-                    log.debug(
-                        "Starte Steam-Login-Iteration. guard_code=%s, login_key=%s, logged_on=%s",
-                        has_guard,
-                        self.login_key_file.exists(),
-                        self.logged_on,
-                    )
-                    res = self._try_login()
-                    self.last_result = res
-
-                    if res == EResult.AccountLoginDeniedNeedTwoFactor:
-                        log.warning("Steam benötigt 2FA. Bitte per !sg CODE senden.")
-                        wait_logged = False
-                        # auf Guard-Code warten
-                        while not self._stop_event.is_set():
-                            with self._lock:
-                                if self.guard_code:
-                                    break
-                            if not wait_logged:
-                                log.debug("Warte auf neuen Guard-Code ...")
-                                wait_logged = True
-                            gevent.sleep(1.0)
-                        log.debug("Guard-Code wurde gesetzt. Fahre mit neuem Login-Fenster fort.")
-                        continue
-
-                    if res != EResult.OK:
-                        log.warning(
-                            "Steam-Login fehlgeschlagen: %s. Details: logged_on=%s, connected=%s. Neuer Versuch in 15s.",
-                            res,
-                            self.logged_on,
-                            getattr(self.client, "connected", None),
-                        )
-                        gevent.sleep(15.0)
-                        continue
-
-                    # Erfolgreich eingeloggt – run_forever läuft bereits im Greenlet.
-                    while not self._stop_event.is_set() and self.logged_on:
-                        gevent.sleep(2.0)
-
-                    if not self._stop_event.is_set():
-                        log.warning("Steam getrennt. Reconnect in 10s.")
-                        gevent.sleep(10.0)
-
-                except Exception:
-                    log.exception("Fehler im Steam Login-Loop")
-                    gevent.sleep(10.0)
-        finally:
+def _fetch_group_counts(sql: str) -> Dict[str, int]:
+    stats: Dict[str, int] = defaultdict(int)
+    try:
+        rows = db.connect().execute(sql).fetchall()
+        for row in rows:
+            status = str(row[0]) if row[0] is not None else "unknown"
             try:
-                if self._io_runner is not None:
-                    self._io_runner.kill()
-            except Exception:
-                pass
+                stats[status] += int(row[1])
+            except (TypeError, ValueError):
+                stats[status] += 0
+    except Exception:  # pragma: no cover - logging only
+        log.exception("Failed to collect Steam statistics", extra={"query": sql})
+    return stats
 
-    def stop(self) -> None:
-        self._stop_event.set()
-        try:
-            self.client.logout()
-        except Exception:
-            log.exception("Steam-Logout fehlgeschlagen", exc_info=True)
+
+def _count_single(sql: str) -> Optional[int]:
+    try:
+        row = db.connect().execute(sql).fetchone()
+        if not row:
+            return 0
+        return int(row[0])
+    except Exception:  # pragma: no cover - logging only
+        log.exception("Failed to fetch Steam counter", extra={"query": sql})
+        return None
 
 
 class SteamMaster(commands.Cog):
-    """Discord Cog zur Verwaltung des Steam-Login-Managers (ohne Presence)."""
+    """Discord cog providing hub-style Steam helpers."""
 
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot, *, mode: Optional[SteamMasterMode] = None) -> None:
         self.bot = bot
-        self.manager: Optional[SteamLoginManager] = None
-        self.data_dir = _data_dir()
-        self._manager_lock = threading.Lock()
+        self.mode = mode or _determine_mode()
+        log.info("SteamMaster initialised in %s mode", self.mode.value)
 
-    async def cog_load(self) -> None:
-        self._ensure_manager()
+    @staticmethod
+    def _format_stats(title: str, stats: Dict[str, int]) -> str:
+        if not stats:
+            return f"{title}: keine Einträge"
+        parts = ", ".join(f"{status}={count}" for status, count in sorted(stats.items()))
+        return f"{title}: {parts}"
 
-    async def cog_unload(self) -> None:
-        if self.manager:
-            self.manager.stop()
-            self.manager.join(timeout=5)
-            self.manager = None
+    def _hub_status(self) -> str:
+        lines = ["mode=hub"]
+        refresh = _refresh_token_path()
+        machine = _machine_auth_path()
+        lines.append(f"refresh_token={'yes' if refresh.exists() else 'no'} ({refresh})")
+        lines.append(f"machine_auth={'yes' if machine.exists() else 'no'} ({machine})")
 
-    # ---------- helpers ----------
-    def _credentials(self) -> tuple[str, str]:
-        username = (os.getenv("STEAM_USERNAME") or "").strip()
-        password = (os.getenv("STEAM_PASSWORD") or "").strip()
-        if not username or not password:
-            raise RuntimeError("STEAM_USERNAME oder STEAM_PASSWORD fehlen.")
-        return username, password
+        fr_stats = _fetch_group_counts(
+            "SELECT status, COUNT(*) FROM steam_friend_requests GROUP BY status"
+        )
+        lines.append(self._format_stats("friend_requests", fr_stats))
 
-    def _ensure_manager(self) -> SteamLoginManager:
-        with self._manager_lock:
-            if self.manager and self.manager.is_alive():
-                return self.manager
-            username, password = self._credentials()
-            manager = SteamLoginManager(username=username, password=password, data_dir=self.data_dir)
-            manager.start()
-            self.manager = manager
-            log.info("SteamLoginManager gestartet (DataDir=%s)", self.data_dir)
-            return manager
+        invite_stats = _fetch_group_counts(
+            "SELECT status, COUNT(*) FROM steam_quick_invites GROUP BY status"
+        )
+        lines.append(self._format_stats("quick_invites", invite_stats))
 
-    async def _get_manager(self, ctx: commands.Context) -> Optional[SteamLoginManager]:
-        try:
-            return self._ensure_manager()
-        except RuntimeError as exc:
-            await ctx.reply(f"❌ {exc}")
-            return None
+        watch_count = _count_single("SELECT COUNT(*) FROM steam_presence_watchlist")
+        if watch_count is not None:
+            lines.append(f"presence_watchlist={watch_count}")
+
+        links_count = _count_single(
+            "SELECT COUNT(DISTINCT steam_id) FROM steam_links WHERE steam_id IS NOT NULL AND steam_id != ''"
+        )
+        if links_count is not None:
+            lines.append(f"linked_accounts={links_count}")
+
+        return "\n".join(lines)
 
     # ---------- commands ----------
     @commands.command(name="sg", aliases=["steam_guard", "steamguard"])
     @commands.has_permissions(administrator=True)
-    async def cmd_sg(self, ctx: commands.Context, code: str) -> None:
-        """Steam Guard / 2FA-Code an den Login-Thread übergeben."""
-        manager = await self._get_manager(ctx)
-        if not manager:
-            return
-        manager.set_guard_code(code)
-        await ctx.reply("✅ Guard-Code gesetzt. Login wird erneut versucht.")
+    async def cmd_sg(self, ctx: commands.Context, code: str) -> None:  # noqa: ARG002
+        """Steam Guard codes are handled by the Node.js bridge."""
+
+        await ctx.reply(
+            "ℹ️ Der Steam Guard-Code muss direkt im Node.js Dienst eingegeben werden."
+        )
 
     @commands.command(name="steam_status")
     @commands.has_permissions(administrator=True)
     async def cmd_status(self, ctx: commands.Context) -> None:
-        """Aktuellen Login-Status inkl. Token-/Sentry-Verfügbarkeit anzeigen."""
-        manager = await self._get_manager(ctx)
-        if not manager:
-            return
-        await ctx.reply(f"```{manager.status()}```")
+        """Show current hub state."""
+
+        await ctx.reply(f"```{self._hub_status()}```")
 
     @commands.command(name="steam_token")
     @commands.has_permissions(administrator=True)
     async def cmd_token(self, ctx: commands.Context) -> None:
-        """Anzeigen, ob ein login_key vorhanden ist (Pfad ohne Inhalt)."""
-        manager = await self._get_manager(ctx)
-        if not manager:
-            return
-        has_key = manager.login_key_file.exists() and manager.login_key_file.stat().st_size > 0
+        """Display stored token information."""
+
+        refresh = _refresh_token_path()
+        machine = _machine_auth_path()
         await ctx.reply(
-            "🔐 login_key: {status}\nPfad: `{path}`".format(
-                status="vorhanden" if has_key else "nicht vorhanden",
-                path=manager.login_key_file,
+            "🔐 refresh_token: {r}\n📁 Pfad: `{rp}`\n🖥️ machine_auth: {m}\n📁 Pfad: `{mp}`".format(
+                r="vorhanden" if refresh.exists() else "nicht vorhanden",
+                rp=refresh,
+                m="vorhanden" if machine.exists() else "nicht vorhanden",
+                mp=machine,
             )
         )
 
     @commands.command(name="steam_token_clear")
     @commands.has_permissions(administrator=True)
     async def cmd_token_clear(self, ctx: commands.Context) -> None:
-        """login_key bewusst löschen (erzwingt nächsten Guard-Login)."""
-        manager = await self._get_manager(ctx)
-        if not manager:
-            return
-        ok = manager.clear_login_key()
-        await ctx.reply("🧹 login_key gelöscht." if ok else "ℹ️ Kein login_key vorhanden.")
+        """Clean up persisted refresh/machine tokens."""
+
+        refresh = _refresh_token_path()
+        machine = _machine_auth_path()
+        removed = []
+        for path, label in ((refresh, "refresh_token"), (machine, "machine_auth")):
+            try:
+                if path.exists():
+                    path.unlink()
+                    removed.append(label)
+            except Exception:  # pragma: no cover - best effort cleanup
+                log.exception("Failed to delete Steam token", extra={"path": str(path)})
+
+        if removed:
+            await ctx.reply("🧹 Gelöscht: {}".format(", ".join(removed)))
+        else:
+            await ctx.reply("ℹ️ Keine Tokens gefunden.")
 
 
 async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(SteamMaster(bot))
+    mode = _determine_mode()
+    if mode is SteamMasterMode.DISABLED:
+        log.info("SteamMaster cog disabled via STEAM_MASTER_MODE=%s", os.getenv("STEAM_MASTER_MODE"))
+        return
+    await bot.add_cog(SteamMaster(bot, mode=mode))

--- a/cogs/steam/steam_presence/README.md
+++ b/cogs/steam/steam_presence/README.md
@@ -1,0 +1,42 @@
+# Steam Presence Bridge
+
+This directory hosts the standalone Node.js service that keeps a Steam Rich
+Presence session alive and synchronises data into the shared SQLite database
+used by the Discord bots.  The Python cog (:mod:`cogs.steam.steam_master`) now
+acts solely as a coordination hub and relies on this service for any direct
+Steam connectivity.
+
+## Running locally
+
+```bash
+npm install
+npm run start
+```
+
+The service reads credentials and other knobs from environment variables.  The
+most important ones are:
+
+| Variable | Description |
+| --- | --- |
+| `STEAM_BOT_USERNAME` / `STEAM_LOGIN` | Steam account name for the initial sign-in. |
+| `STEAM_BOT_PASSWORD` / `STEAM_PASSWORD` | Password for the account above. |
+| `STEAM_TOTP_SECRET` | Optional shared secret for generating 2FA codes. |
+| `DEADLOCK_DB_PATH` | Location of the SQLite database (defaults to the same path as the Python services). |
+
+A refresh token is stored inside `.steam-data/refresh.token`.  Once available,
+the bridge logs in automatically without reusing the plaintext credentials.
+Token files sit next to the service and are shared with the Python modules via
+the commands exposed by ``steam_master``.
+
+## Interaction with the Python bots
+
+* Rich Presence updates and friend snapshots are written into the SQLite
+  database so other cogs can react to them.
+* Token files (`refresh.token` and `machine_auth_token.txt`) are inspected and
+  can be cleaned via Discord commands provided by the hub cog.
+* The watchlist, friend request queue, and quick invite tables are polled by the
+  service.  Python modules can insert rows into those tables without needing a
+  direct Steam connection.
+
+For troubleshooting enable verbose logging by setting ``LOG_LEVEL=debug`` before
+starting the service.

--- a/cogs/steam/steam_presence/index.js
+++ b/cogs/steam/steam_presence/index.js
@@ -1,0 +1,982 @@
+#!/usr/bin/env node
+/**
+ * Steam Rich Presence bridge (safe login flow, v5 tokens)
+ * - Auto-Login NUR wenn ./.steam-data/refresh.token existiert
+ * - Sonst: KEIN Auto-Login, nur via "!sg <CODE>" oder "<CODE>" + Passwort/TOTP
+ * - KEINE device-Approval-Wartepfade (kein Timeout). Bei device -> abbrechen & auf !sg warten.
+ * - Bei ungültigem refresh.token: löschen, nicht automatisch neu versuchen.
+ * - Machine-Auth-Token: wird gespeichert/geladen; reduziert erneute Guard-Prompts bei PW-Login.
+ * - Restliche Funktionen (Presence, DB etc.) bleiben unverändert.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const readline = require('readline');
+const SteamUser = require('steam-user');
+const SteamTotp = require('steam-totp');
+const Database = require('better-sqlite3');
+
+let SteamIDCtor = null;
+try { SteamIDCtor = require('steamid'); } catch { SteamIDCtor = SteamUser.SteamID; }
+
+// ---------------- Config ----------------
+const APP_ID = parseInt(process.env.DEADLOCK_APP_ID || '1422450', 10);
+const WATCH_REFRESH_MS = parseInt(process.env.RP_WATCH_REFRESH_SEC || '60', 10) * 1000;
+const POLL_INTERVAL_MS  = parseInt(process.env.RP_POLL_INTERVAL_MS  || '30000', 10);
+const FRIEND_QUEUE_INTERVAL_MS = parseInt(process.env.FRIEND_QUEUE_INTERVAL_MS || '1000', 10);
+const FRIEND_SYNC_INTERVAL_MS = parseInt(process.env.FRIEND_SYNC_INTERVAL_SEC || '60', 10) * 1000;
+const FRIEND_REQUEST_INTERVAL_MS = parseInt(process.env.FRIEND_REQUEST_INTERVAL_MS || '5000', 10);
+const FRIEND_SNAPSHOT_INTERVAL_MS = parseInt(process.env.FRIEND_SNAPSHOT_INTERVAL_MS || '30000', 10);
+
+// Token-Bucket
+const CHUNK_SIZE      = parseInt(process.env.RP_CHUNK_SIZE      || '20', 10);
+const CHUNK_DELAY_MS  = parseInt(process.env.RP_CHUNK_DELAY_MS  || '500', 10);
+const MAX_REQ_PER_MIN = parseInt(process.env.RP_MAX_REQ_PER_MIN || '120', 10);
+
+// Logging
+const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const LOG_LEVEL = (process.env.LOG_LEVEL || 'info').toLowerCase();
+const LOG_THRESHOLD = Object.prototype.hasOwnProperty.call(LOG_LEVELS, LOG_LEVEL) ? LOG_LEVELS[LOG_LEVEL] : LOG_LEVELS.info;
+function log(level, message, extra = undefined) {
+  const lvl = LOG_LEVELS[level];
+  if (lvl === undefined || lvl > LOG_THRESHOLD) return;
+  const payload = { time: new Date().toISOString(), level, msg: message };
+  if (extra && typeof extra === 'object') for (const [k, v] of Object.entries(extra)) if (v !== undefined) payload[k] = v;
+  console.log(JSON.stringify(payload));
+}
+
+// --------------- Single-instance lock ---------------
+const LOCK_PATH = path.join(__dirname, 'presence.lock');
+let lockFd;
+
+function acquireLock(attempt = 0) {
+  try {
+    lockFd = fs.openSync(LOCK_PATH, 'wx');
+    fs.writeFileSync(lockFd, String(process.pid));
+    return true;
+  } catch (err) {
+    if (!err || err.code !== 'EEXIST') {
+      console.error('Failed to acquire presence lock:', err && err.message ? err.message : String(err));
+      process.exit(1);
+    }
+
+    let existingPid = Number.NaN;
+    try {
+      existingPid = parseInt(fs.readFileSync(LOCK_PATH, 'utf8'), 10);
+    } catch {
+      existingPid = Number.NaN;
+    }
+
+    if (Number.isFinite(existingPid) && existingPid > 0) {
+      try {
+        process.kill(existingPid, 0);
+        console.error(`Another presence instance seems to be running (pid=${existingPid}). Exiting.`);
+        process.exit(0);
+      } catch (checkErr) {
+        if (checkErr && checkErr.code === 'ESRCH') {
+          try { fs.unlinkSync(LOCK_PATH); } catch {}
+          if (attempt === 0) return acquireLock(attempt + 1);
+        } else {
+          const msg = checkErr && checkErr.message ? checkErr.message : String(checkErr);
+          console.error(`Presence lock held by pid=${existingPid} but cannot be verified: ${msg}`);
+          process.exit(0);
+        }
+      }
+    } else {
+      try { fs.unlinkSync(LOCK_PATH); } catch {}
+      if (attempt === 0) return acquireLock(attempt + 1);
+    }
+  }
+
+  console.error('Unable to acquire presence lock. Exiting.');
+  process.exit(0);
+}
+
+acquireLock();
+
+function cleanupLock(){
+  try {
+    if (typeof lockFd === 'number') {
+      fs.closeSync(lockFd);
+      lockFd = undefined;
+    }
+    fs.unlinkSync(LOCK_PATH);
+  } catch {}
+}
+process.on('exit', cleanupLock); process.on('SIGINT', ()=>{ cleanupLock(); process.exit(0); });
+process.on('SIGTERM', ()=>{ cleanupLock(); process.exit(0); });
+
+// --------------- DB init ---------------
+function resolveDbPath() {
+  if (process.env.DEADLOCK_DB_PATH) return path.resolve(process.env.DEADLOCK_DB_PATH);
+  const baseDir = process.env.DEADLOCK_DB_DIR ? path.resolve(process.env.DEADLOCK_DB_DIR) : path.join(os.homedir(), 'Documents', 'Deadlock', 'service');
+  return path.join(baseDir, 'deadlock.sqlite3');
+}
+const dbPath = resolveDbPath();
+log('info', 'Using SQLite database', { dbPath });
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+db.pragma('synchronous = NORMAL');
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_rich_presence (
+    steam_id TEXT PRIMARY KEY,
+    app_id INTEGER,
+    status TEXT,
+    status_text TEXT,
+    display TEXT,
+    player_group TEXT,
+    player_group_size INTEGER,
+    connect TEXT,
+    mode TEXT,
+    map TEXT,
+    party_size INTEGER,
+    raw_json TEXT,
+    last_update INTEGER,
+    updated_at INTEGER
+  )
+`).run();
+
+const presenceSchemaMigrations = [
+  "ALTER TABLE steam_rich_presence ADD COLUMN status_text TEXT",
+  "ALTER TABLE steam_rich_presence ADD COLUMN mode TEXT",
+  "ALTER TABLE steam_rich_presence ADD COLUMN map TEXT",
+  "ALTER TABLE steam_rich_presence ADD COLUMN party_size INTEGER",
+  "ALTER TABLE steam_rich_presence ADD COLUMN updated_at INTEGER"
+];
+for (const sql of presenceSchemaMigrations) {
+  try { db.prepare(sql).run(); }
+  catch (err) { if (!String(err.message || err).includes('duplicate column name')) throw err; }
+}
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_friend_requests (
+    steam_id TEXT PRIMARY KEY,
+    status TEXT DEFAULT 'pending',
+    requested_at INTEGER DEFAULT (strftime('%s','now')),
+    last_attempt INTEGER,
+    attempts INTEGER DEFAULT 0,
+    error TEXT
+  )
+`).run();
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_presence_watchlist (
+    steam_id TEXT PRIMARY KEY,
+    note TEXT,
+    added_at INTEGER DEFAULT (strftime('%s','now'))
+  )
+`).run();
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS steam_friend_snapshots (
+    steam_id TEXT PRIMARY KEY,
+    relationship INTEGER,
+    persona_state INTEGER,
+    persona_name TEXT,
+    game_app_id INTEGER,
+    game_name TEXT,
+    last_logoff INTEGER,
+    last_logon INTEGER,
+    persona_flags INTEGER,
+    avatar_hash TEXT,
+    persona_json TEXT,
+    rich_presence_json TEXT,
+    updated_at INTEGER
+  )
+`).run();
+
+try {
+  db.prepare(`CREATE INDEX IF NOT EXISTS idx_friend_snapshots_updated ON steam_friend_snapshots(updated_at)`).run();
+} catch (err) {
+  log('debug', 'Failed to ensure friend snapshot index', { error: err && err.message ? err.message : String(err) });
+}
+
+const upsertPresence = db.prepare(`
+  INSERT INTO steam_rich_presence(
+    steam_id, app_id, status, status_text, display, player_group, player_group_size,
+    connect, mode, map, party_size, raw_json, last_update, updated_at
+  )
+  VALUES (
+    @steam_id, @app_id, @status, @status_text, @display, @player_group, @player_group_size,
+    @connect, @mode, @map, @party_size, @raw_json, @updated_at, @updated_at
+  )
+  ON CONFLICT(steam_id) DO UPDATE SET
+    app_id=excluded.app_id,
+    status=excluded.status,
+    status_text=excluded.status_text,
+    display=excluded.display,
+    player_group=excluded.player_group,
+    player_group_size=excluded.player_group_size,
+    connect=excluded.connect,
+    mode=excluded.mode,
+    map=excluded.map,
+    party_size=excluded.party_size,
+    raw_json=excluded.raw_json,
+    last_update=excluded.last_update,
+    updated_at=excluded.updated_at
+`);
+
+const upsertFriendSnapshot = db.prepare(`
+  INSERT INTO steam_friend_snapshots(
+    steam_id, relationship, persona_state, persona_name, game_app_id, game_name,
+    last_logoff, last_logon, persona_flags, avatar_hash, persona_json, rich_presence_json, updated_at
+  ) VALUES (
+    @steam_id, @relationship, @persona_state, @persona_name, @game_app_id, @game_name,
+    @last_logoff, @last_logon, @persona_flags, @avatar_hash, @persona_json, @rich_presence_json, @updated_at
+  )
+  ON CONFLICT(steam_id) DO UPDATE SET
+    relationship=excluded.relationship,
+    persona_state=excluded.persona_state,
+    persona_name=excluded.persona_name,
+    game_app_id=excluded.game_app_id,
+    game_name=excluded.game_name,
+    last_logoff=excluded.last_logoff,
+    last_logon=excluded.last_logon,
+    persona_flags=excluded.persona_flags,
+    avatar_hash=excluded.avatar_hash,
+    persona_json=excluded.persona_json,
+    rich_presence_json=excluded.rich_presence_json,
+    updated_at=excluded.updated_at
+`);
+
+const watchlistQuery = db.prepare(`
+  SELECT DISTINCT steam_id FROM (
+    SELECT steam_id FROM steam_links
+    UNION
+    SELECT steam_id FROM steam_presence_watchlist
+  )
+  WHERE steam_id IS NOT NULL AND steam_id != ''
+`);
+
+const steamLinksForFriendsQuery = db.prepare(`
+  SELECT steam_id FROM steam_links
+  WHERE steam_id IS NOT NULL AND steam_id != ''
+`);
+
+const pendingFriendRequestQuery = db.prepare(`
+  SELECT steam_id, attempts FROM steam_friend_requests
+  WHERE status = 'pending'
+  ORDER BY COALESCE(last_attempt, 0) ASC, requested_at ASC
+  LIMIT 1
+`);
+
+const markFriendRequestSuccessStmt = db.prepare(`
+  UPDATE steam_friend_requests
+  SET status='sent', last_attempt=@ts, attempts=@attempts, error=NULL
+  WHERE steam_id=@steam_id
+`);
+
+const markFriendRequestFailureStmt = db.prepare(`
+  UPDATE steam_friend_requests
+  SET last_attempt=@ts, attempts=@attempts, error=@error
+  WHERE steam_id=@steam_id
+`);
+
+const markFriendRequestKnownStmt = db.prepare(`
+  UPDATE steam_friend_requests
+  SET status='sent', error=NULL
+  WHERE steam_id=@steam_id
+`);
+
+const enqueueFriendRequestStmt = db.prepare(`
+  INSERT INTO steam_friend_requests(steam_id, status)
+  VALUES (@steam_id, 'pending')
+  ON CONFLICT(steam_id) DO UPDATE SET
+    status=excluded.status,
+    last_attempt=NULL,
+    attempts=0,
+    error=NULL
+  WHERE steam_friend_requests.status NOT IN ('sent', 'pending')
+`);
+
+function toOptionalInt(value) {
+  if (value === undefined || value === null) return null;
+  const num = Number(value);
+  if (Number.isNaN(num) || !Number.isFinite(num)) return null;
+  return Math.trunc(num);
+}
+
+function sanitizeForJson(value, seen = new Set()) {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString('utf8');
+  }
+  if (value && typeof value.getSteamID64 === 'function') {
+    try { return value.getSteamID64(); }
+    catch { return String(value); }
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForJson(item, seen));
+  }
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return null;
+    }
+    seen.add(value);
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (v === undefined) continue;
+      out[String(k)] = sanitizeForJson(v, seen);
+    }
+    seen.delete(value);
+    return out;
+  }
+  try {
+    return String(value);
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonStringify(value) {
+  if (value === undefined) return null;
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    try {
+      return JSON.stringify(sanitizeForJson(value));
+    } catch (err2) {
+      log('debug', 'Failed to stringify friend payload', {
+        error: err2 && err2.message ? err2.message : String(err2),
+      });
+      return null;
+    }
+  }
+}
+
+function logSteamTimeout(context, err) {
+  const eresult = err && typeof err.eresult === 'number' ? err.eresult : undefined;
+  const rawMessage = err && err.message ? String(err.message) : (err ? String(err) : '');
+  const lower = rawMessage.toLowerCase();
+  const isTimeout = (typeof eresult === 'number' && eresult === SteamUser.EResult.Timeout)
+    || lower.includes('timeout');
+  if (!isTimeout) return false;
+  log('warn', 'STEAM_TIMEOUT', {
+    context,
+    hint: 'Steam meldet ein Timeout – laut Steam bitte später erneut versuchen.',
+    steamMessage: rawMessage || null,
+    eresult,
+  });
+  return true;
+}
+
+function normalizeRichPresence(source) {
+  const normalized = {};
+  if (!source || typeof source !== 'object') {
+    return normalized;
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string') {
+      normalized[key] = value;
+      continue;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      normalized[key] = String(value);
+      continue;
+    }
+    if (Buffer.isBuffer(value)) {
+      normalized[key] = value.toString('utf8');
+      continue;
+    }
+    try {
+      normalized[key] = String(value);
+    } catch {
+      normalized[key] = '[unserializable]';
+    }
+  }
+  return normalized;
+}
+
+function normalizePersona(persona) {
+  if (!persona || typeof persona !== 'object') return {};
+  const sanitized = sanitizeForJson(persona);
+  return sanitized && typeof sanitized === 'object' ? sanitized : {};
+}
+
+// --------------- Steam client ---------------
+// WICHTIG: v5 – wir nutzen Token-Flow
+const client = new SteamUser({ renewRefreshTokens: true });
+client.setOption('promptSteamGuardCode', false);
+client.setOption('machineName', 'DeadlockPresence');
+
+// Feste „Cookie“-Ablage
+const DATA_DIR = path.join(__dirname, '.steam-data');
+try { fs.mkdirSync(DATA_DIR, { recursive: true }); } catch {}
+client.setOption('dataDirectory', DATA_DIR);
+
+// Login creds (für Erstlogin ohne Token)
+const loginAccount = process.env.STEAM_BOT_USERNAME || process.env.STEAM_LOGIN || process.env.STEAM_ACCOUNT;
+const password   = process.env.STEAM_BOT_PASSWORD || process.env.STEAM_PASSWORD || '';
+const totpSecret = process.env.STEAM_TOTP_SECRET || '';
+let   guardCode  = ''; // nur via !sg
+
+// Token-Dateien (neuer Standard)
+const REFRESH_TOKEN_PATH = path.join(DATA_DIR, 'refresh.token');
+const MACHINE_TOKEN_PATH = path.join(DATA_DIR, 'machine_auth_token.txt');
+
+let refreshToken = '';
+try { if (fs.existsSync(REFRESH_TOKEN_PATH)) { refreshToken = fs.readFileSync(REFRESH_TOKEN_PATH, 'utf8').trim(); if (refreshToken) log('info', 'Loaded refresh token', { path: REFRESH_TOKEN_PATH }); } }
+catch (err) { log('warn', 'Failed to read refresh token', { path: REFRESH_TOKEN_PATH, error: err.message }); }
+
+let machineAuthToken = '';
+try { if (fs.existsSync(MACHINE_TOKEN_PATH)) { machineAuthToken = fs.readFileSync(MACHINE_TOKEN_PATH, 'utf8').trim(); if (machineAuthToken) log('info', 'Loaded machine auth token', { path: MACHINE_TOKEN_PATH }); } }
+catch (err) { log('warn', 'Failed to read machine auth token', { path: MACHINE_TOKEN_PATH, error: err.message }); }
+
+// --------------- State ---------------
+let isLoggedOn = false;
+let isConnecting = false;
+
+// Keine Device-Approval-Engine, keine Timer/Timeouts.
+let reconnectTimer = null;
+let backoffMs = 10_000;
+const backoffMaxMs = 5 * 60_000;
+
+// Token-Bucket
+let tokens = MAX_REQ_PER_MIN;
+setInterval(() => { tokens = MAX_REQ_PER_MIN; }, 60_000);
+
+let lastFriendActionAt = 0;
+let friendSnapshotTimer = null;
+let friendSnapshotInFlight = false;
+const friendSnapshotMemo = new Map();
+
+// --------------- Helpers ---------------
+function tryRequestPresence(steamID) {
+  if (tokens <= 0) return false;
+  try { client.requestFriendRichPresence(steamID, APP_ID); tokens--; return true; }
+  catch (err) {
+    logSteamTimeout('requestFriendRichPresence', err);
+    log('debug', 'requestFriendRichPresence failed', { steamId: String(steamID), error: err.message });
+    return false;
+  }
+}
+
+function scheduleFriendSnapshot(delayMs = 2000) {
+  const delay = Math.max(0, Number.isFinite(delayMs) ? delayMs : 0);
+  if (friendSnapshotTimer) return;
+  friendSnapshotTimer = setTimeout(() => {
+    friendSnapshotTimer = null;
+    snapshotFriends().catch(() => {});
+  }, delay);
+}
+
+async function snapshotFriends() {
+  if (!isLoggedOn || friendSnapshotInFlight) return;
+  const friendMap = client.myFriends || {};
+  const ids = Object.keys(friendMap).filter((sid) => sid);
+  if (ids.length === 0) return;
+  friendSnapshotInFlight = true;
+  try {
+    const personas = await new Promise((resolve) => {
+      try {
+        client.getPersonas(ids, (err, data) => {
+          if (err) {
+            logSteamTimeout('getPersonas', err);
+            log('warn', 'Failed to fetch friend personas', { error: err.message });
+            resolve(null);
+            return;
+          }
+          resolve(data || {});
+        });
+      } catch (err) {
+        logSteamTimeout('getPersonas', err);
+        log('warn', 'getPersonas threw error', { error: err && err.message ? err.message : String(err) });
+        resolve(null);
+      }
+    });
+    if (!personas) return;
+
+    const now = Math.floor(Date.now() / 1000);
+    let updated = 0;
+    for (const sid of ids) {
+      const personaRaw = personas[sid] || null;
+      const persona = normalizePersona(personaRaw);
+      let presenceRaw = {};
+      try {
+        presenceRaw = client.getFriendRichPresence(sid) || {};
+      } catch (err) {
+        try {
+          const steamObj = new SteamIDCtor(sid);
+          presenceRaw = client.getFriendRichPresence(steamObj) || {};
+        } catch (inner) {
+          const error = inner && inner.message ? inner.message : err && err.message ? err.message : String(inner || err);
+          log('debug', 'getFriendRichPresence snapshot failed', { steamId: sid, error });
+        }
+      }
+      const presence = normalizeRichPresence(presenceRaw);
+      const relationship = friendMap[sid] ?? null;
+
+      const dedupeKeyObj = {
+        relationship,
+        persona,
+        presence,
+      };
+      const dedupeKey = safeJsonStringify(dedupeKeyObj) || '__friend_snapshot__';
+      if (friendSnapshotMemo.get(sid) === dedupeKey) {
+        continue;
+      }
+      friendSnapshotMemo.set(sid, dedupeKey);
+
+      const entry = {
+        steam_id: sid,
+        relationship: toOptionalInt(relationship),
+        persona_state: toOptionalInt(persona.persona_state ?? persona.personaState),
+        persona_name: persona.player_name || persona.persona_name || null,
+        game_app_id: toOptionalInt(persona.gameid ?? persona.game_played_app_id ?? persona.gameid_appid),
+        game_name: persona.game_name || null,
+        last_logoff: toOptionalInt(persona.last_logoff),
+        last_logon: toOptionalInt(persona.last_logon),
+        persona_flags: toOptionalInt(persona.persona_flags),
+        avatar_hash: persona.avatar_hash || null,
+        persona_json: safeJsonStringify(persona),
+        rich_presence_json: safeJsonStringify(presence),
+        updated_at: now,
+      };
+      try {
+        upsertFriendSnapshot.run(entry);
+        updated++;
+      } catch (err) {
+        log('warn', 'Failed to persist friend snapshot', { steamId: sid, error: err && err.message ? err.message : String(err) });
+      }
+    }
+    if (updated > 0) {
+      log('debug', 'FRIEND_SNAPSHOT_UPDATED', { count: updated });
+    }
+  } finally {
+    friendSnapshotInFlight = false;
+  }
+}
+
+function scheduleReconnect(opts = {}) {
+  const { immediate = false } = opts;
+  if (reconnectTimer || isConnecting) return;
+  const delay = immediate ? 0 : backoffMs;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    backoffMs = Math.min(backoffMaxMs, Math.floor(backoffMs * 1.8));
+    // Nur reconnecten, wenn wir Auto-Login dürfen (refresh token existiert)
+    if (refreshToken) {
+      log('info', 'Reconnecting to Steam…', { delayMs: delay, nextBackoffMs: backoffMs });
+      logOn();
+    } else {
+      log('info', 'No refresh token present — staying idle (waiting for !sg).');
+    }
+  }, delay);
+}
+function resetBackoff() { backoffMs = 10_000; }
+
+function buildLogonOptions() {
+  // v5-Regeln:
+  // - Mit refreshToken: KEIN accountName/password/machineAuthToken übergeben
+  if (refreshToken) {
+    return { refreshToken };
+  }
+
+  // Ohne refreshToken: Passwort-Login erforderlich (+ 2FA), optional machineAuthToken
+  if (!loginAccount) {
+    log('error', 'Missing STEAM_BOT_USERNAME/STEAM_LOGIN env variable'); throw new Error('No account');
+  }
+  if (!password) {
+    log('error', 'Missing STEAM_BOT_PASSWORD and no refresh token — cannot login. Use !sg <CODE> after setting password env.');
+    throw new Error('No password');
+  }
+
+  const opts = { accountName: loginAccount, password };
+
+  // 2FA: bevorzugt TOTP, sonst Guard-Code via !sg
+  if (totpSecret) {
+    opts.twoFactorCode = SteamTotp.generateAuthCode(totpSecret);
+  } else if (guardCode) {
+    opts.twoFactorCode = guardCode.trim().toUpperCase();
+    guardCode = '';
+  } else {
+    log('info', 'No refresh token and no guard/TOTP code — skipping login until !sg.');
+    throw new Error('No code');
+  }
+
+  // machineAuthToken hilft, erneute device-Prompts zu vermeiden (entscheidet Steam)
+  if (machineAuthToken) {
+    opts.machineAuthToken = machineAuthToken;
+  }
+  return opts;
+}
+
+function logOn() {
+  if (isLoggedOn || isConnecting) return;
+
+  // Regel: nur auto, wenn refreshToken existiert
+  if (!refreshToken && !guardCode && !totpSecret) {
+    log('info', 'Auto-login disabled (no refresh token). Waiting for !sg <CODE>.');
+    return;
+  }
+
+  let options;
+  try { options = buildLogonOptions(); }
+  catch { return; }
+
+  isConnecting = true;
+  log('info', 'Logging in to Steam', { usingRefreshToken: Boolean(options.refreshToken), account: options.refreshToken ? undefined : loginAccount });
+  try { client.logOn(options); }
+  catch (e) { isConnecting = false; log('error', 'client.logOn threw', { error: e.message || String(e) }); }
+}
+
+// --------------- stdin (!sg / status) ---------------
+const stdinRL = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+stdinRL.on('line', (line) => {
+  let txt = (line || '').trim();
+  if (!txt) return;
+
+  // Plain Code: 5–7 alphanumerische Zeichen
+  const plainCodeMatch = txt.match(/^[A-Z0-9]{5,7}$/i);
+
+  // Varianten: "!sg CODE", "sg CODE", "/sg CODE"
+  const cmdMatch = txt.match(/^(?:!|\/)?sg\s+([A-Z0-9]{5,7})$/i);
+
+  if (/^status$/i.test(txt)) {
+    log('info', 'Status', {
+      isLoggedOn, isConnecting,
+      hasRefreshToken: Boolean(refreshToken),
+      hasMachineAuthToken: Boolean(machineAuthToken),
+      dataDir: DATA_DIR
+    });
+    return;
+  }
+
+  if (/^cancel$/i.test(txt)) {
+    try { client.logOff(); } catch {}
+    isConnecting = false;
+    log('info', 'Cancelled any ongoing login; waiting for !sg.');
+    return;
+  }
+
+  const code = cmdMatch ? cmdMatch[1] : (plainCodeMatch ? plainCodeMatch[0] : null);
+  if (code) {
+    guardCode = code.toUpperCase();
+    log('info', 'Guard code received via console; attempting login now.');
+    logOn(); // unmittelbarer Versuch (durch User ausgelöst)
+    return;
+  }
+
+  log('info', 'Unknown console input. Use "!sg <CODE>" or "STATUS".');
+});
+
+// --------------- Presence helpers ---------------
+const watchList = new Map();
+function refreshWatchList() {
+  let rows = [];
+  try { rows = watchlistQuery.all(); }
+  catch (err) { log('error', 'Failed to read watchlist from DB', { error: err.message }); return; }
+  const next = new Set();
+  for (const row of rows) {
+    const sid = String(row.steam_id || '').trim();
+    if (!sid) continue;
+    next.add(sid);
+    if (!watchList.has(sid)) {
+      try {
+        const steamID = new SteamIDCtor(sid);
+        watchList.set(sid, steamID);
+        log('info', 'Added SteamID to watch list', { steamId: sid });
+        if (isLoggedOn) tryRequestPresence(steamID);
+      } catch (err) {
+        log('warn', 'Ignoring invalid SteamID', { steamId: sid, error: err.message });
+      }
+    }
+  }
+  for (const sid of Array.from(watchList.keys())) {
+    if (!next.has(sid)) { watchList.delete(sid); log('info', 'Removed SteamID from watch list', { steamId: sid }); }
+  }
+}
+
+async function pollPresence() {
+  if (!isLoggedOn || watchList.size === 0) return;
+  const ids = Array.from(watchList.values());
+  for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + CHUNK_SIZE);
+    for (const sid of chunk) {
+      if (tokens <= 0) {
+        log('warn', 'Presence request budget exhausted; pausing chunk loop until refill.');
+        await new Promise(r => setTimeout(r, Math.max(CHUNK_DELAY_MS, 1000)));
+      }
+      tryRequestPresence(sid);
+    }
+    await new Promise(r => setTimeout(r, CHUNK_DELAY_MS));
+  }
+}
+
+function ensureFriendQueued(steamId) {
+  if (!steamId) return;
+  const sid = String(steamId).trim();
+  if (!sid) return;
+  try {
+    const result = enqueueFriendRequestStmt.run({ steam_id: sid });
+    if (result.changes > 0) {
+      log('info', 'FA_OUTGOING_ENQUEUED', { steamId: sid });
+    }
+  } catch (err) {
+    logSteamTimeout('enqueueFriendRequest', err);
+    log('warn', 'Failed to enqueue friend request', { steamId: sid, error: err.message });
+  }
+}
+
+function processFriendQueue() {
+  if (!isLoggedOn) return;
+  if (Date.now() - lastFriendActionAt < FRIEND_REQUEST_INTERVAL_MS) return;
+  let job;
+  try { job = pendingFriendRequestQuery.get(); }
+  catch (err) { log('warn', 'Failed to read pending friend request', { error: err.message }); return; }
+  if (!job || !job.steam_id) return;
+  const steamId = String(job.steam_id).trim();
+  if (!steamId) return;
+  const attempts = Number(job.attempts || 0) + 1;
+  const ts = Math.floor(Date.now() / 1000);
+  try {
+    client.addFriend(steamId);
+    markFriendRequestSuccessStmt.run({ steam_id: steamId, attempts, ts });
+    lastFriendActionAt = Date.now();
+    log('info', 'FA_OUTGOING_SENT', { steamId, attempts });
+  } catch (err) {
+    lastFriendActionAt = Date.now();
+    const message = err && err.message ? err.message : String(err);
+    markFriendRequestFailureStmt.run({ steam_id: steamId, attempts, ts, error: message });
+    const lower = message.toLowerCase();
+    const timeoutLogged = logSteamTimeout('addFriend', err);
+    if ((err && err.eresult === SteamUser.EResult.RateLimitExceeded) || lower.includes('rate')) {
+      log('warn', 'FA_RATE_LIMIT_HIT', { steamId, error: message });
+    } else if (!timeoutLogged) {
+      log('warn', 'FA_OUTGOING_FAILED', { steamId, error: message });
+    }
+  }
+}
+
+function syncFriendsWithDb() {
+  if (!isLoggedOn) return;
+  let rows;
+  try { rows = steamLinksForFriendsQuery.all(); }
+  catch (err) { log('error', 'Failed to read steam_links for friend sync', { error: err.message }); return; }
+  const desired = new Set();
+  for (const row of rows) {
+    const sid = String(row.steam_id || '').trim();
+    if (sid) desired.add(sid);
+  }
+  const friendMap = client.myFriends || {};
+  for (const sid of desired) {
+    const relationship = friendMap[sid];
+    if (relationship === SteamUser.EFriendRelationship.Friend || relationship === SteamUser.EFriendRelationship.RequestInitiator) {
+      try { markFriendRequestKnownStmt.run({ steam_id: sid }); } catch {}
+      continue;
+    }
+    ensureFriendQueued(sid);
+  }
+}
+
+// --------------- Events ---------------
+client.on('loggedOn', () => {
+  isLoggedOn = true;
+  isConnecting = false;
+  resetBackoff();
+  log('info', 'Logged in to Steam', { account: loginAccount, usingRefreshToken: Boolean(refreshToken) });
+  client.setPersona(SteamUser.EPersonaState.Online);
+  friendSnapshotMemo.clear();
+
+  setTimeout(() => {
+    refreshWatchList();
+    pollPresence().catch(() => {});
+    syncFriendsWithDb();
+    processFriendQueue();
+    snapshotFriends().catch(() => {});
+  }, 5000);
+});
+
+// Neuer Standard: Refresh-Token speichern
+client.on('refreshToken', (token) => {
+  try {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(REFRESH_TOKEN_PATH, token, 'utf8');
+    refreshToken = token;
+    log('info', 'Stored refresh token', { path: REFRESH_TOKEN_PATH });
+  } catch (err) {
+    log('warn', 'Failed to persist refresh token', { path: REFRESH_TOKEN_PATH, error: err.message });
+  }
+});
+
+// Neuer Standard: Machine-Auth-Token speichern
+client.on('machineAuthToken', (token) => {
+  try {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(MACHINE_TOKEN_PATH, token, 'utf8');
+    machineAuthToken = token;
+    log('info', 'Stored machine auth token', { path: MACHINE_TOKEN_PATH });
+  } catch (err) {
+    log('warn', 'Failed to write machine auth token', { path: MACHINE_TOKEN_PATH, error: err.message });
+  }
+});
+
+// SteamGuard-Flow: keine device-Wartepfade
+client.on('steamGuard', (domain, callback) => {
+  const d = (domain || 'device').toLowerCase();
+  if (d === 'device') {
+    log('warn', 'Steam Guard (device) requested — blocked by config. Use !sg <CODE> instead.');
+    try { client.logOff(); } catch {}
+    isConnecting = false;
+    return; // kein callback()-Loop
+  }
+  // Codebasierte Varianten: akzeptieren, wenn vorhanden
+  if (totpSecret) {
+    const code = SteamTotp.generateAuthCode(totpSecret);
+    log('info', 'Supplying TOTP Steam Guard code');
+    return void callback(code);
+  }
+  if (guardCode) {
+    const code = guardCode.trim().toUpperCase(); guardCode = '';
+    log('info', 'Supplying guard code from console (!sg)');
+    return void callback(code);
+  }
+  // Kein Code vorhanden: abbrechen, auf !sg warten
+  log('info', 'Steam Guard required but no code present — waiting for !sg.');
+  try { client.logOff(); } catch {}
+  isConnecting = false;
+});
+
+client.on('friendRichPresence', (steamID, appID) => {
+  const sid64 = typeof steamID.getSteamID64 === 'function' ? steamID.getSteamID64() : String(steamID);
+  const presence = normalizeRichPresence(client.getFriendRichPresence(steamID) || {});
+  const entry = {
+    steam_id: sid64,
+    app_id: Number(appID) || null,
+    status: presence.status || null,
+    status_text: presence.status_text || presence.status || null,
+    display: presence.steam_display || presence.display || null,
+    player_group: presence.steam_player_group || null,
+    player_group_size: toOptionalInt(presence.steam_player_group_size),
+    connect: presence.connect || null,
+    mode: presence.mode || presence.gamemode || null,
+    map: presence.map || null,
+    party_size: toOptionalInt(presence.party_size),
+    raw_json: safeJsonStringify(presence) || JSON.stringify({}),
+    updated_at: Math.floor(Date.now() / 1000),
+  };
+  try {
+    upsertPresence.run(entry);
+    log('info', 'PRESENCE_UPSERT', {
+      steamId: sid64,
+      updatedAt: entry.updated_at,
+      status: entry.status_text || entry.status || null,
+      display: entry.display,
+      mode: entry.mode || null,
+    });
+    friendSnapshotMemo.delete(sid64);
+    scheduleFriendSnapshot(1500);
+  }
+  catch (err) { log('error', 'Failed to persist rich presence', { steamId: sid64, error: err.message }); }
+});
+
+client.on('friendRelationship', (steamID, relationship) => {
+  const sid64 = typeof steamID.getSteamID64 === 'function' ? steamID.getSteamID64() : String(steamID);
+  friendSnapshotMemo.delete(sid64);
+  scheduleFriendSnapshot(2000);
+  if (relationship === SteamUser.EFriendRelationship.RequestRecipient) {
+    try {
+      client.addFriend(steamID);
+      lastFriendActionAt = Date.now();
+      log('info', 'FA_INCOMING_ACCEPTED', { steamId: sid64 });
+      try { markFriendRequestKnownStmt.run({ steam_id: sid64 }); } catch {}
+    } catch (err) {
+      log('error', 'Failed to accept incoming friend request', { steamId: sid64, error: err.message });
+    }
+    return;
+  }
+  if (relationship === SteamUser.EFriendRelationship.Friend || relationship === SteamUser.EFriendRelationship.RequestInitiator) {
+    try { markFriendRequestKnownStmt.run({ steam_id: sid64 }); } catch {}
+  }
+  if (relationship === SteamUser.EFriendRelationship.None) {
+    if (watchList.delete(sid64)) log('info', 'Friend relationship removed, deleting from watch list', { steamId: sid64 });
+    log('info', 'FA_REMOVED', { steamId: sid64 });
+  }
+});
+
+client.on('disconnected', (eresult, msg) => {
+  isLoggedOn = false;
+  isConnecting = false;
+  log('warn', 'Steam disconnected', { eresult, msg });
+  logSteamTimeout('disconnected', { eresult, message: msg });
+  friendSnapshotMemo.clear();
+  // Nur reconnecten, wenn wir einen Refresh-Token haben (Auto-Login erlaubt)
+  if (refreshToken) scheduleReconnect();
+});
+
+client.on('error', (err) => {
+  log('error', 'Steam client error', { error: err.message });
+  logSteamTimeout('client_error', err);
+  const text = (err && err.message) ? err.message.toLowerCase() : '';
+
+  // Offensichtliche Token-Probleme -> Token löschen, NICHT automatisch neu versuchen
+  if (text.includes('invalid refresh') || text.includes('expired') || text.includes('refresh token')) {
+    if (refreshToken) {
+      log('warn', 'Refresh token likely invalid — clearing token and waiting for !sg');
+      try { fs.unlinkSync(REFRESH_TOKEN_PATH); } catch {}
+      refreshToken = '';
+    }
+    isConnecting = false;
+    return;
+  }
+
+  // RateLimit o.ä. -> kein Autosturm; nur bei vorhandenem Token später reconnecten
+  if (text.includes('ratelimit') || text.includes('rate limit') || text.includes('throttle')) {
+    isConnecting = false;
+    log('warn', 'Server throttle — no auto retry without refresh token. Wait and use !sg if needed.');
+    return;
+  }
+
+  // Standard: bei sonstigen Errors nur reconnecten, wenn Token existiert
+  isConnecting = false;
+  if (refreshToken) scheduleReconnect();
+});
+
+client.on('webSession', () => log('debug', 'Web session established'));
+
+// --------------- Kickoff / Shutdown ---------------
+refreshWatchList();
+setInterval(refreshWatchList, WATCH_REFRESH_MS);
+setInterval(() => { pollPresence().catch(() => {}); }, POLL_INTERVAL_MS);
+setInterval(() => {
+  try { processFriendQueue(); }
+  catch (err) { log('warn', 'processFriendQueue failed', { error: err.message }); }
+}, Math.max(250, FRIEND_QUEUE_INTERVAL_MS));
+setInterval(() => {
+  try { syncFriendsWithDb(); }
+  catch (err) { log('warn', 'syncFriendsWithDb failed', { error: err.message }); }
+}, Math.max(1_000, FRIEND_SYNC_INTERVAL_MS));
+setInterval(() => {
+  try { snapshotFriends().catch(() => {}); }
+  catch (err) { log('warn', 'snapshotFriends failed', { error: err.message }); }
+}, Math.max(5_000, FRIEND_SNAPSHOT_INTERVAL_MS));
+
+// Startregel: nur wenn refresh.token existiert
+if (refreshToken) {
+  log('info', 'Auto-login enabled (refresh.token present).');
+  logOn();
+} else {
+  log('info', 'Auto-login disabled (no refresh token). Waiting for !sg <CODE>.');
+}
+
+function shutdown() {
+  log('info', 'Shutting down presence service');
+  try { client.logOff(); } catch {}
+  try { db.close(); } catch {}
+  process.exit(0);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('uncaughtException', (err) => { log('error', 'Uncaught exception', { error: err.stack || err.message }); shutdown(); });

--- a/cogs/steam/steam_presence/package-lock.json
+++ b/cogs/steam/steam_presence/package-lock.json
@@ -1,0 +1,999 @@
+{
+  "name": "deadlock-steam-presence",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deadlock-steam-presence",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^9.4.0",
+        "steam-totp": "^2.1.1",
+        "steam-user": "^5.0.0"
+      }
+    },
+    "node_modules/@bbob/parser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.9.0.tgz",
+      "integrity": "sha512-tldSYsMoEclke/B1nqL7+HbYMWZHTKvpbEHRSHuY+sZvS1o7Jpdfjb+KPpwP9wLI3p3r7GPv69/wGy+Xibs9yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bbob/plugin-helper": "^2.9.0"
+      }
+    },
+    "node_modules/@bbob/plugin-helper": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.9.0.tgz",
+      "integrity": "sha512-idpUcNQ2co6T1oU/7/DG/ZRfipSSkTn9Ozw9f5vaXH7nzV3qhqZnhFVlHTzGGnRlzKlBwWOBzOdWi4Zeqg1c5A==",
+      "license": "MIT"
+    },
+    "node_modules/@doctormckay/stdlib": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+      "integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+      "license": "MIT",
+      "dependencies": {
+        "psl": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@doctormckay/steam-crypto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
+      "integrity": "sha512-lsxgLw640gEdZBOXpVIcYWcYD+V+QbtEsMPzRvjmjz2XXKc7QeEMyHL07yOFRmay+cUwO4ObKTJO0dSInEuq5g==",
+      "license": "MIT"
+    },
+    "node_modules/@doctormckay/user-agents": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@doctormckay/user-agents/-/user-agents-1.0.0.tgz",
+      "integrity": "sha512-F+sL1YmebZTY2CnjoR9BXFEULpq7y8dxyLx48LZVa0BSDseXdLG/DtPISfM1iNv1XKCeiBzVNfAT/MOQ69v1Zw==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.0.tgz",
+      "integrity": "sha512-5x08bUtU8hfboMTrJ7mEO4CpepS9yBwAqcL52y86SWNmbPX8LVbNs3EP4cNrIZgdjk2NAlP2ahNihozpoZIxSg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.14.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/binarykvparser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binarykvparser/-/binarykvparser-2.3.0.tgz",
+      "integrity": "sha512-B1N5ZxC8I9oSLis7Rg36DxsZJoIikUGU2XwpI0FKFCaPIJIEYi0B9UeIk3QU006axzq0TI9KC3iXelfGGgnWew==",
+      "bundleDependencies": [
+        "long"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "long": "^3.2.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha512-IuzSdmADppkZ6DlpycMkm8l9zeEq16fWtLvunEwFiYciR/BHo4E8/xs5piFquG+Za8OWmMqHF8zuRviz2LHvRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "~3"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.1.tgz",
+      "integrity": "sha512-y/K/1OCha04OXOxzo3cXJYtIzEk/CUMBb7Okipxueu0u+xCiuoocbwPyh1smUBasOobo4GAYmjgjD9Vh5zI51w==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/file-manager/node_modules/@doctormckay/stdlib": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.16.1.tgz",
+      "integrity": "sha512-XhuUOzElz6fnNdt70IYNKqhPAEpGaL4JHOhAvklRh0hAhVPW+/wLxaWT3DWUbaG5Dta5YvIp7+cZK3GhIpAuug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/kvparser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/kvparser/-/kvparser-1.0.2.tgz",
+      "integrity": "sha512-5P/5qpTAHjVYWqcI55B3yQwSY2FUrYYrJj5i65V1Wmg7/4W4OnBcaodaEvLyVuugeOnS+BAaKm9LbPazGJcRyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/lzma": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
+      "integrity": "sha512-DcfiawQ1avYbW+hsILhF38IKAlnguc/fjHrychs9hdxe4qLykvhT5VTGNs5YRWgaNePh7NTxGD4uv4gKsRomCQ==",
+      "license": "MIT",
+      "bin": {
+        "lzma.js": "bin/lzma.js"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
+      "integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-bignumber": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+      "integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/permessage-deflate": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
+      "integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "*"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/steam-appticket": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.2.tgz",
+      "integrity": "sha512-zwDwZALGv3RanE8RHNYcQU3u4Ez23EzMuQ4Lh15uIHddpDh6TI6uFGbC0HNyt6y+UJYSILe77A33VhFZKQiaqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^1.6.0",
+        "@doctormckay/steam-crypto": "^1.2.0",
+        "bytebuffer": "^5.0.1",
+        "protobufjs": "^6.8.8",
+        "steamid": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/@doctormckay/stdlib": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.16.1.tgz",
+      "integrity": "sha512-XhuUOzElz6fnNdt70IYNKqhPAEpGaL4JHOhAvklRh0hAhVPW+/wLxaWT3DWUbaG5Dta5YvIp7+cZK3GhIpAuug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/steam-appticket/node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/steam-appticket/node_modules/steamid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+      "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
+      "license": "MIT",
+      "dependencies": {
+        "cuint": "^0.2.1"
+      }
+    },
+    "node_modules/steam-session": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/steam-session/-/steam-session-1.9.4.tgz",
+      "integrity": "sha512-MLvg1uMLEOIRHZS5LKruy1w5OqHb8EL7TeMxIY2a4mUcaVOgszz060+jo4c7s3gFeedyuoqGcfwJrR0pLKYzLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^2.9.0",
+        "@doctormckay/user-agents": "^1.0.0",
+        "debug": "^4.3.4",
+        "kvparser": "^1.0.1",
+        "node-bignumber": "^1.2.2",
+        "protobufjs": "^7.1.0",
+        "socks-proxy-agent": "^7.0.0",
+        "steamid": "^2.0.0",
+        "tiny-typed-emitter": "^2.1.0",
+        "websocket13": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/steam-totp": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.2.tgz",
+      "integrity": "sha512-bTKlc/NoIUQId+my+O556s55DDsNNXfVIPWFDNVu68beql7AJhV0c+GTjFxfwCDYfdc4NkAme+0WrDdnY2D2VA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/steam-user": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-5.2.3.tgz",
+      "integrity": "sha512-6Yzaa0l7fcSRaaJzHjfuqettYqAsrW3+1AEu/cj4M/lgRYXa0DfOAjuWj0/wesfkogwuXNE4N/ZMZvNir8TVtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bbob/parser": "^2.2.0",
+        "@doctormckay/stdlib": "^2.9.1",
+        "@doctormckay/steam-crypto": "^1.2.0",
+        "adm-zip": "^0.5.10",
+        "binarykvparser": "^2.2.0",
+        "bytebuffer": "^5.0.0",
+        "file-manager": "^2.0.0",
+        "kvparser": "^1.0.1",
+        "lzma": "^2.3.2",
+        "protobufjs": "^7.2.4",
+        "socks-proxy-agent": "^7.0.0",
+        "steam-appticket": "^1.0.1",
+        "steam-session": "^1.8.0",
+        "steam-totp": "^2.0.1",
+        "steamid": "^2.0.0",
+        "websocket13": "^4.0.0",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/steamid": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+      "integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket13": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-4.0.0.tgz",
+      "integrity": "sha512-/ujP9ZfihyAZIXKGxcYpoe7Gj4r5o3WYSfP93o9lVNhhqoBtYba4m1s3mxdjKZu/HOhX5Mcqrt89dv/gC3b06A==",
+      "license": "MIT",
+      "dependencies": {
+        "@doctormckay/stdlib": "^2.7.1",
+        "bytebuffer": "^5.0.1",
+        "permessage-deflate": "^0.1.7",
+        "tiny-typed-emitter": "^2.1.0",
+        "websocket-extensions": "^0.1.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
+    }
+  }
+}

--- a/cogs/steam/steam_presence/package.json
+++ b/cogs/steam/steam_presence/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "deadlock-steam-presence",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Steam Rich Presence collector for the Deadlock Discord bots.",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.0",
+    "steam-totp": "^2.1.1",
+    "steam-user": "^5.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- remove the legacy Steam login manager so the steam_master cog operates purely as a hub for database/token helpers
- keep administrative commands for status and token maintenance while directing Steam Guard handling to the Node bridge
- document the Node.js Steam presence service and allow its README to be tracked in git

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f13f469acc832f86ac48223ecdec0c