### PR TITLE
Fix Twitch cog setup for newer discord.py builds

### DIFF
--- a/cogs/twitch/__init__.py
+++ b/cogs/twitch/__init__.py
@@ -44,7 +44,14 @@ async def setup(bot):
 
     # Der Command gehört logisch zum Cog, wird aber bewusst außerhalb von add_cog registriert,
     # um Doppel-Registrierungen des Decorators zu vermeiden.
-    prefix_command._set_cog(cog)  # type: ignore[attr-defined]
+    set_cog = getattr(prefix_command, "_set_cog", None)
+    if callable(set_cog):
+        set_cog(cog)
+    else:  # Fallback für discord.py-Versionen ohne _set_cog (z. B. neuere Py-Cord Builds)
+        try:
+            setattr(prefix_command, "cog", cog)  # type: ignore[attr-defined]
+        except AttributeError:
+            log.debug("Prefix command binding API unavailable; continuing without binding")
     bot.add_command(prefix_command)
     cog.set_prefix_command(prefix_command)
     log.info("Registered !twl prefix command via setup hook")


### PR DESCRIPTION
## Summary
- add a compatibility fallback when registering the !twl prefix command so the Twitch cog no longer crashes on discord.py versions without Command._set_cog

## Testing
- not run (discord.py dependency is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68f15d8d132c832fb40239f70174065b