### PR TITLE
Ensure Twitch onboarding uses shared Deadlock SQLite database

### DIFF
--- a/cogs/twitch/storage.py
+++ b/cogs/twitch/storage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sqlite3
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterable, Optional
 
 log = logging.getLogger("TwitchStreams")
@@ -10,13 +11,29 @@ log = logging.getLogger("TwitchStreams")
 # --- zentrale DB anbinden, mit Fallback auf lokale Datei --------------------
 try:
     from service.db import get_conn as _central_get_conn  # type: ignore
+    from service.db import db_path as _central_db_path  # type: ignore
 except Exception:
     _central_get_conn = None  # type: ignore[assignment]
+    _central_db_path = None  # type: ignore[assignment]
 
-_FALLBACK_PATH = os.getenv("DEADLOCK_DB_PATH") or os.path.join(os.getcwd(), "deadlock.db")
-_dir = os.path.dirname(_FALLBACK_PATH)
-if _dir:
-    os.makedirs(_dir, exist_ok=True)
+if _central_get_conn is None:
+    _fallback = os.getenv("DEADLOCK_DB_PATH")
+    if not _fallback:
+        if _central_db_path is not None:
+            _fallback = _central_db_path()
+        else:
+            user_profile = os.environ.get("USERPROFILE")
+            if user_profile:
+                base_dir = Path(user_profile) / "Documents" / "Deadlock" / "service"
+            else:
+                base_dir = Path.home() / "Documents" / "Deadlock" / "service"
+            _fallback = str(base_dir / "deadlock.sqlite3")
+    _FALLBACK_PATH = _fallback
+else:
+    _FALLBACK_PATH = _central_db_path() if "_central_db_path" in globals() and _central_db_path else None
+
+if _FALLBACK_PATH:
+    Path(_FALLBACK_PATH).parent.mkdir(parents=True, exist_ok=True)
 
 
 @contextmanager

--- a/service/db.py
+++ b/service/db.py
@@ -17,8 +17,9 @@ import atexit
 import sqlite3
 import threading
 import logging
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Iterator, Optional
 
 # ---- Env-Keys (nur diese beiden werden unterstützt) ----
 ENV_DB_PATH = "DEADLOCK_DB_PATH"   # kompletter Pfad zur DB-Datei (höchste Prio)
@@ -124,6 +125,14 @@ def connect() -> sqlite3.Connection:
         init_schema(_CONN)
 
     return _CONN
+
+
+@contextmanager
+def get_conn() -> Iterator[sqlite3.Connection]:
+    """Contextmanager, der die zentrale Verbindung thread-safe bereitstellt."""
+    conn = connect()
+    with _LOCK:
+        yield conn
 
 
 def init_schema(conn: Optional[sqlite3.Connection] = None) -> None:


### PR DESCRIPTION
## Summary
- expose a thread-safe context manager in the central SQLite helper so other modules can share the same connection
- update the Twitch storage helper to prefer the shared Deadlock database path used across the bots, including the Windows location

## Testing
- python -m compileall service/db.py cogs/twitch/storage.py

------
https://chatgpt.com/codex/tasks/task_e_68f4d099cb88832f98ad7e2af05bcdd3