### PR TITLE
Restrict partner flag to verified Twitch streamers

### DIFF
--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -76,7 +76,12 @@ class TwitchMonitoringMixin:
             for row in rows:
                 login = str(row["twitch_login"])
                 tracked.append((login, str(row["twitch_user_id"]), bool(row["require_discord_link"])))
-                partner_logins.add(login.lower())
+                try:
+                    is_verified = self._is_partner_verified(dict(row), now_utc)
+                except AttributeError:
+                    is_verified = False
+                if is_verified:
+                    partner_logins.add(login.lower())
         except Exception:
             log.exception("Konnte tracked Streamer nicht aus DB lesen")
             tracked = []


### PR DESCRIPTION
## Summary
- only mark tracked Twitch streamers as partners when they have an active verification entry

## Testing
- python -m compileall cogs/twitch/monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68f4d46a68ec832f8a9c4c081817086d