### PR TITLE
Mark tracked Twitch streamers as partners

### DIFF
--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -63,13 +63,11 @@ class TwitchMonitoringMixin:
         if not self._category_id:
             await self._ensure_category_id()
 
-        now_utc = datetime.now(tz=timezone.utc)
         partner_logins: set[str] = set()
         try:
             with storage.get_conn() as c:
                 rows = c.execute(
-                    "SELECT twitch_login, twitch_user_id, require_discord_link, "
-                    "       manual_verified_permanent, manual_verified_until "
+                    "SELECT twitch_login, twitch_user_id, require_discord_link "
                     "FROM twitch_streamers"
                 ).fetchall()
             tracked: List[Tuple[str, str, bool]] = []


### PR DESCRIPTION
## Summary
- treat every stored Twitch streamer as a partner during monitoring
- remove the verification gate introduced in the previous change

## Testing
- python -m compileall cogs/twitch/monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68f4d46a68ec832f8a9c4c081817086d