### PR TITLE
Restore Twitch live embed styling

### DIFF
--- a/cogs/twitch/constants.py
+++ b/cogs/twitch/constants.py
@@ -10,6 +10,7 @@ TWITCH_DASHBOARD_PORT = 8765
 
 TWITCH_LANGUAGE = "de"
 TWITCH_TARGET_GAME_NAME = "Deadlock"
+TWITCH_BRAND_COLOR_HEX = 0x9146FF                     # offizielles Twitch-Lila für Embeds
 TWITCH_REQUIRED_DISCORD_MARKER = ""                # optionaler Marker im Profiltext (zusätzl. zur Discord-URL)
 
 # Benachrichtigungskanäle

--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -10,7 +10,12 @@ import discord
 from discord.ext import tasks
 
 from . import storage
-from .constants import INVITES_REFRESH_INTERVAL_HOURS, POLL_INTERVAL_SECONDS, TWITCH_TARGET_GAME_NAME
+from .constants import (
+    INVITES_REFRESH_INTERVAL_HOURS,
+    POLL_INTERVAL_SECONDS,
+    TWITCH_BRAND_COLOR_HEX,
+    TWITCH_TARGET_GAME_NAME,
+)
 from .logger import log
 
 
@@ -338,7 +343,7 @@ class TwitchMonitoringMixin:
             title=f"{display_name} ist LIVE in {game}!",
             description=title,
             url=url,
-            colour=discord.Color(0x9146FF),
+            colour=discord.Color(TWITCH_BRAND_COLOR_HEX),
             timestamp=timestamp,
         )
 
@@ -353,7 +358,7 @@ class TwitchMonitoringMixin:
             embed.set_image(url=f"{thumbnail_url}?rand={cache_bust}")
 
         embed.set_footer(text="Auf Twitch ansehen für mehr Deadlock-Action!")
-        embed.set_author(name=display_name, url=url)
+        embed.set_author(name=f"🔴 {display_name}", url=url)
 
         return embed
 
@@ -362,5 +367,11 @@ class TwitchMonitoringMixin:
         """Stellt eine View mit Button zum Öffnen des Streams bereit."""
 
         view = discord.ui.View(timeout=None)
-        view.add_item(discord.ui.Button(label="Auf Twitch ansehen", url=url))
+        view.add_item(
+            discord.ui.Button(
+                label="Auf Twitch ansehen",
+                style=discord.ButtonStyle.link,
+                url=url,
+            )
+        )
         return view


### PR DESCRIPTION
## Summary
- add a Twitch brand color constant for reuse in embed styling
- adjust the live embed author to include a red live indicator and reuse the brand color
- force the live stream button to use the link style for the Twitch preview view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f56bf1ea54832fa76cd7d9c67b2c09