### PR TITLE
Fix dashboard binding error on Windows

### DIFF
--- a/service/dashboard.py
+++ b/service/dashboard.py
@@ -455,7 +455,13 @@ class DashboardServer:
 
             # Unter Windows bleibt der Port häufig kurzzeitig im TIME_WAIT-Zustand.
             # reuse_address ermöglicht schnelle Neustarts ohne Fehlermeldung.
-            site_kwargs: Dict[str, Any] = {"reuse_address": True}
+            #
+            # Allerdings führt reuse_address auf Windows-Installationen (insbesondere
+            # seit Python 3.11) zu "WinError 10013". Daher aktivieren wir die Option
+            # nur auf Plattformen, die sie sicher unterstützen.
+            site_kwargs: Dict[str, Any] = {}
+            if os.name != "nt":
+                site_kwargs["reuse_address"] = True
 
             try:
                 self._site = web.TCPSite(self._runner, self.host, self.port, **site_kwargs)


### PR DESCRIPTION
## Summary
- disable aiohttp's reuse_address option when running the dashboard on Windows to avoid WinError 10013 during bind

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f573fc0fe0832faea188d64d51e663