### PR TITLE
Integrate cog explorer into unified management view

### DIFF
--- a/service/dashboard.py
+++ b/service/dashboard.py
@@ -66,6 +66,18 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
             grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
             gap: 1rem;
         }
+        .cog-management {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        .cog-management .card {
+            height: 100%;
+        }
+        .card h3 {
+            margin-top: 0;
+        }
         .card {
             background: #161616;
             border-radius: 8px;
@@ -244,26 +256,31 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
                 <p id=\"bot-guilds\">-</p>
                 <p id=\"bot-latency\">-</p>
             </div>
-            <div class=\"card\">
-                <h2>Cog Explorer</h2>
-                <div id=\"tree-container\" class=\"tree-container\"></div>
-            </div>
         </div>
     </section>
 
     <section>
-        <h2>Cogs</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Status</th>
-                    <th>Namespace</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody id=\"cog-table\"></tbody>
-        </table>
+        <h2>Cog Management</h2>
+        <div class=\"cog-management\">
+            <div class=\"card\">
+                <h3>Cog Explorer</h3>
+                <div id=\"tree-container\" class=\"tree-container\"></div>
+            </div>
+            <div class=\"card\">
+                <h3>Cogs</h3>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Status</th>
+                            <th>Namespace</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id=\"cog-table\"></tbody>
+                </table>
+            </div>
+        </div>
     </section>
 
     <section>
@@ -522,6 +539,32 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
                 reloadCog(node.path);
             });
             actions.appendChild(reloadBtn);
+
+            const loadBtn = document.createElement('button');
+            loadBtn.textContent = 'Load';
+            loadBtn.className = 'load';
+            if (node.loaded) {
+                loadBtn.disabled = true;
+            }
+            loadBtn.addEventListener('click', (ev) => {
+                ev.preventDefault();
+                ev.stopPropagation();
+                loadCog(node.path);
+            });
+            actions.appendChild(loadBtn);
+
+            const unloadBtn = document.createElement('button');
+            unloadBtn.textContent = 'Unload';
+            unloadBtn.className = 'unload';
+            if (!node.loaded) {
+                unloadBtn.disabled = true;
+            }
+            unloadBtn.addEventListener('click', (ev) => {
+                ev.preventDefault();
+                ev.stopPropagation();
+                unloadCog(node.path);
+            });
+            actions.appendChild(unloadBtn);
         }
         const blockBtn = document.createElement('button');
         if (node.blocked) {


### PR DESCRIPTION
## Summary
- reorganize the dashboard layout to present the cog explorer alongside the cog table in one management section
- expose load and unload controls directly from explorer nodes so the tree offers the same management options as the list

## Testing
- python -m compileall service/dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68f654d20abc832fab0fa5fef2488203