### PR TITLE
Ensure presence CSV initialises and log path

### DIFF
--- a/cogs/steam/steam_presence/deadlock_presence_logger.js
+++ b/cogs/steam/steam_presence/deadlock_presence_logger.js
@@ -50,6 +50,11 @@ class DeadlockPresenceLogger {
   start() {
     if (this.started) return;
     this.started = true;
+    try {
+      this.ensureCsvHeader();
+    } catch (err) {
+      this.log('warn', 'Failed to initialise presence CSV', { error: err.message || String(err) });
+    }
     this.client.on('loggedOn', this.handlers.loggedOn);
     this.client.on('friendsList', this.handlers.friendsList);
     this.client.on('user', this.handlers.user);

--- a/cogs/steam/steam_presence/index.js
+++ b/cogs/steam/steam_presence/index.js
@@ -185,6 +185,7 @@ const presenceLogger = new DeadlockPresenceLogger(client, log, {
   language: process.env.STEAM_PRESENCE_LANGUAGE || 'german',
   csvPath: path.join(DATA_DIR, 'deadlock_presence_log.csv'),
 });
+log('info', 'Presence logger configured', { csvPath: presenceLogger.csvPath });
 presenceLogger.start();
 
 // ---------- Helpers ----------


### PR DESCRIPTION
## Summary
- ensure the presence logger creates the CSV header as soon as the service starts
- log the resolved CSV path so operators know where the file is written

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f67f336ea0832faa4447d8a2571f6d