### PR TITLE
Fix partner status detection in dashboard

### DIFF
--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -91,7 +91,8 @@ class TwitchMonitoringMixin:
         try:
             with storage.get_conn() as c:
                 rows = c.execute(
-                    "SELECT twitch_login, twitch_user_id, require_discord_link "
+                    "SELECT twitch_login, twitch_user_id, require_discord_link, "
+                    "       manual_verified_permanent, manual_verified_until "
                     "FROM twitch_streamers"
                 ).fetchall()
             tracked: List[Tuple[str, str, bool]] = []


### PR DESCRIPTION
## Summary
- include partner verification fields when loading tracked Twitch streamers
- ensure manually verified partners are correctly flagged in stats logging and dashboard views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6c8b4c9e4832f9cb10fc785d7b7ff