### PR TITLE
Treat all tracked streamers as partners

### DIFF
--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -87,7 +87,6 @@ class TwitchMonitoringMixin:
             await self._ensure_category_id()
 
         partner_logins: set[str] = set()
-        now_utc = datetime.now(tz=timezone.utc)
         try:
             with storage.get_conn() as c:
                 rows = c.execute(
@@ -98,12 +97,7 @@ class TwitchMonitoringMixin:
             for row in rows:
                 login = str(row["twitch_login"])
                 tracked.append((login, str(row["twitch_user_id"]), bool(row["require_discord_link"])))
-                try:
-                    is_verified = self._is_partner_verified(dict(row), now_utc)
-                except AttributeError:
-                    is_verified = False
-                if is_verified:
-                    partner_logins.add(login.lower())
+                partner_logins.add(login.lower())
         except Exception:
             log.exception("Konnte tracked Streamer nicht aus DB lesen")
             tracked = []


### PR DESCRIPTION
## Summary
- mark every streamer stored in the database as a partner when loading monitoring data
- remove the manual verification checks so partner status is independent of verification fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6c8b4c9e4832f9cb10fc785d7b7ff