### PR TITLE
Ensure dashboard treats tracked streamers as partners

### DIFF
--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -117,8 +117,9 @@ class TwitchMonitoringMixin:
                         "is_verified": is_verified,
                     }
                 )
-                if is_verified:
-                    partner_logins.add(login.lower())
+                login_lower = login.lower()
+                if login_lower:
+                    partner_logins.add(login_lower)
         except Exception:
             log.exception("Konnte tracked Streamer nicht aus DB lesen")
             tracked = []


### PR DESCRIPTION
## Summary
- always treat tracked Twitch streamers as partners when logging live data so the dashboard sees them as partners
- override leaderboard statistics to flag any stored tracked streamer as a partner regardless of verification status

## Testing
- python -m compileall cogs/twitch/monitoring.py cogs/twitch/leaderboard.py

------
https://chatgpt.com/codex/tasks/task_e_68f6e5da5f84832f89ae323b39738bd9