### PR TITLE
Improve logging and error handling in onboarding flows

### DIFF
--- a/cogs/feedback_hub.py
+++ b/cogs/feedback_hub.py
@@ -248,8 +248,8 @@ class FeedbackHub(commands.Cog):
         else:
             try:
                 await ctx.message.delete()
-            except discord.HTTPException:
-                pass
+            except discord.HTTPException as exc:
+                log.debug("Konnte Ursprungsnachricht nach Interface-Erstellung nicht löschen: %s", exc)
 
     @create_feedback_interface.error
     async def on_create_feedback_error(

--- a/cogs/rules_channel.py
+++ b/cogs/rules_channel.py
@@ -54,8 +54,8 @@ async def _create_user_thread(interaction: discord.Interaction) -> Optional[disc
         )
         await thread.add_user(interaction.user)
         return thread
-    except discord.Forbidden:
-        pass
+    except discord.Forbidden as exc:
+        log.debug("Privater Thread konnte nicht erstellt werden: %s", exc)
 
     # Fallback: Public Thread
     try:
@@ -76,8 +76,8 @@ async def _send_step(thread: discord.Thread, embed: discord.Embed, view: discord
     msg = await thread.send(embed=embed, view=view)
     try:
         setattr(view, "bound_message", msg)  # kompatibel mit DM-Views
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("View besitzt kein bound_message-Attribut: %s", exc)
     try:
         await view.wait()
     finally:
@@ -141,8 +141,8 @@ class RulesPanel(commands.Cog):
                 await interaction.response.send_message(f"🧵 Onboarding in {thread.mention} gestartet.", ephemeral=True)
             else:
                 await interaction.followup.send(f"🧵 Onboarding in {thread.mention} gestartet.", ephemeral=True)
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug("Konnte Start-Hinweis nicht senden: %s", exc)
 
         # Bevorzugt: WelcomeDM um Hilfe bitten
         wdm = self.bot.get_cog("WelcomeDM")

--- a/cogs/steam/steam_presence/deadlock_presence_logger.js
+++ b/cogs/steam/steam_presence/deadlock_presence_logger.js
@@ -293,27 +293,38 @@ class DeadlockPresenceLogger {
     }
   }
 
-  ensureCsvHeader() {
-    if (this.headerWritten && fs.existsSync(this.csvPath)) {
-      return;
+    ensureCsvHeader() {
+      if (this.headerWritten && fs.existsSync(this.csvPath)) {
+        return;
+      }
+      if (!fs.existsSync(this.csvPath)) {
+        const header = [
+          'timestamp_iso',
+          'steamid64',
+          'name',
+          'playing_appid',
+          'deadlock',
+          'localized_string',
+          'hero_guess',
+          'minutes',
+          'party_hint',
+          'raw_rich_presence_json',
+        ].join(',');
+        try {
+          const fd = fs.openSync(this.csvPath, 'ax');
+          try {
+            fs.writeFileSync(fd, `${header}\n`, 'utf8');
+          } finally {
+            fs.closeSync(fd);
+          }
+        } catch (err) {
+          if (!err || err.code !== 'EEXIST') {
+            throw err;
+          }
+        }
+      }
+      this.headerWritten = true;
     }
-    if (!fs.existsSync(this.csvPath)) {
-      const header = [
-        'timestamp_iso',
-        'steamid64',
-        'name',
-        'playing_appid',
-        'deadlock',
-        'localized_string',
-        'hero_guess',
-        'minutes',
-        'party_hint',
-        'raw_rich_presence_json',
-      ].join(',');
-      fs.writeFileSync(this.csvPath, `${header}\n`, 'utf8');
-    }
-    this.headerWritten = true;
-  }
 
   flushBatch(immediate = false) {
     if (this.batchRows.length === 0) {

--- a/cogs/twitch/admin.py
+++ b/cogs/twitch/admin.py
@@ -129,8 +129,8 @@ class TwitchAdminMixin:
         try:
             if bool(row.get("manual_verified_permanent")):
                 return True
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug("Partner-Flag konnte nicht gelesen werden: %s", exc)
 
         until_raw = row.get("manual_verified_until")
         until_dt = cls._parse_db_datetime(str(until_raw)) if until_raw else None

--- a/cogs/twitch/base.py
+++ b/cogs/twitch/base.py
@@ -107,8 +107,9 @@ class TwitchBaseCog(commands.Cog):
             if self.api is not None:
                 try:
                     await self.api.aclose()
-                except asyncio.CancelledError:
-                    pass
+                except asyncio.CancelledError as exc:
+                    log.debug("Schließen der TwitchAPI-Session abgebrochen: %s", exc)
+                    raise
                 except Exception:
                     log.exception("TwitchAPI-Session konnte nicht geschlossen werden")
 

--- a/cogs/twitch/dashboard.py
+++ b/cogs/twitch/dashboard.py
@@ -70,8 +70,8 @@ class Dashboard:
             parsed = int(raw)
             if parsed > 0:
                 return parsed
-        except ValueError:
-            pass
+        except ValueError as exc:
+            log.debug("Ungültiger Portwert '%s': %s", raw, exc)
         log.warning("Ungültiger Portwert '%s' – verwende %s", raw, default)
         return default
 
@@ -1349,5 +1349,5 @@ def build_app(
 # Erlaubt Aufrufe wie: Dashboard.build_app(...)
 try:
     Dashboard.build_app = staticmethod(build_app)  # type: ignore[attr-defined]
-except Exception:
-    pass
+except Exception as exc:
+    log.debug("Konnte Dashboard.build_app nicht setzen: %s", exc)

--- a/cogs/twitch/leaderboard.py
+++ b/cogs/twitch/leaderboard.py
@@ -182,8 +182,12 @@ class TwitchLeaderboardView(discord.ui.View):
                     "Nur der ursprüngliche Aufrufer kann diese Steuerung verwenden.",
                     ephemeral=True,
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug(
+                    "Konnte Hinweis für fremde Leaderboard-Interaktion nicht senden (user_id=%s): %s",
+                    interaction.user.id,
+                    exc,
+                )
             return False
         return True
 
@@ -241,8 +245,8 @@ class TwitchLeaderboardView(discord.ui.View):
         if self._message is not None:
             try:
                 await self._message.edit(view=self)
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug("Konnte Leaderboard-Timeout-Nachricht nicht aktualisieren: %s", exc)
 
     @discord.ui.button(label="Sortierung", style=discord.ButtonStyle.primary, row=0)
     async def sort_button(

--- a/cogs/twitch/monitoring.py
+++ b/cogs/twitch/monitoring.py
@@ -361,8 +361,8 @@ class TwitchMonitoringMixin:
         if isinstance(started_at_raw, str) and started_at_raw:
             try:
                 timestamp = datetime.fromisoformat(started_at_raw.replace("Z", "+00:00"))
-            except ValueError:
-                pass
+            except ValueError as exc:
+                log.debug("Ungültiger started_at-Wert '%s': %s", started_at_raw, exc)
 
         embed = discord.Embed(
             title=f"{display_name} ist LIVE in {game}!",

--- a/cogs/twitch/storage.py
+++ b/cogs/twitch/storage.py
@@ -4,7 +4,6 @@ import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, Optional
 
 log = logging.getLogger("TwitchStreams")
 

--- a/cogs/voice_activity_tracker.py
+++ b/cogs/voice_activity_tracker.py
@@ -3,7 +3,6 @@ from discord.ext import commands, tasks
 import logging
 import json
 import os
-import asyncio
 import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional

--- a/cogs/welcome_dm/dm_main.py
+++ b/cogs/welcome_dm/dm_main.py
@@ -107,8 +107,8 @@ class WelcomeDM(commands.Cog):
         finally:
             try:
                 await msg.delete()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("_send_step_embed_channel: Nachricht konnte nicht gelöscht werden: %s", exc)
         return bool(getattr(view, "proceed", False))
 
     # ---------------- Öffentliche Flows ----------------
@@ -176,8 +176,8 @@ class WelcomeDM(commands.Cog):
                     await view.wait()
                     try:
                         await msg.delete()
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("StreamerIntro DM-Message nicht gelöscht: %s", exc)
                 except Exception:
                     logger.debug("StreamerIntro Schritt übersprungen (kein Modul/Fehler).", exc_info=True)
 
@@ -295,8 +295,8 @@ class WelcomeDM(commands.Cog):
                 await view.wait()
                 try:
                     await msg.delete()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("StreamerIntro Channel-Message nicht gelöscht: %s", exc)
             except Exception:
                 logger.debug("StreamerIntro Schritt (Thread) übersprungen.", exc_info=True)
 
@@ -342,8 +342,8 @@ class WelcomeDM(commands.Cog):
             if closing_lines:
                 try:
                     await channel.send("\n\n".join(closing_lines))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("Abschlussnachricht im Channel konnte nicht gesendet werden: %s", exc)
 
             return True
 

--- a/cogs/welcome_dm/step_steam_link.py
+++ b/cogs/welcome_dm/step_steam_link.py
@@ -59,8 +59,8 @@ def _prefer_discord_deeplink(browser_url: Optional[str]) -> Tuple[Optional[str],
             if _DEEPLINK_EN:
                 deeplink = urlunparse(("discord", "-/oauth2/authorize", "", "", u.query, ""))
                 return deeplink, browser_url
-    except Exception:
-        pass
+    except Exception as exc:
+        _LOGGER.debug("Konnte Deep-Link URL nicht parsen (%s): %s", browser_url, exc)
     return browser_url, None
 
 _STEAM_LINK_DM_DESC = dedent(

--- a/main_bot.py
+++ b/main_bot.py
@@ -18,10 +18,13 @@ import datetime as _dt
 import pytz
 import traceback
 
+import importlib
+import inspect
+import hashlib
+
 import discord
 from discord.ext import commands
 # --- DEBUG: Herkunft der geladenen Dateien ausgeben ---
-import sys as _sys, os as _os, importlib, inspect, logging as _logging, hashlib
 import re
 
 try:
@@ -528,8 +531,8 @@ class MasterBot(commands.Bot):
                 name=f"{len(self.active_cogs())} Cogs | {pfx}help",
             )
             await self.change_presence(activity=activity)
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.exception("Konnte Presence nicht aktualisieren: %s", exc)
 
     # --------------------- Lifecycle ----------------------------------
     async def setup_hook(self):
@@ -1144,8 +1147,8 @@ async def _graceful_shutdown(bot: MasterBot, reason: str = "signal",
     try:
         if _kill_timer:
             _kill_timer.cancel()
-    except Exception:
-        pass
+    except Exception as exc:
+        logging.getLogger().debug("Kill-Timer konnte nicht gestoppt werden: %s", exc)
 
     # 3) Loop stoppen + harter Exit als letzte Eskalationsstufe
     try:

--- a/service/db.py
+++ b/service/db.py
@@ -21,6 +21,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional
 
+
+log = logging.getLogger(__name__)
+
 # ---- Env-Keys (nur diese beiden werden unterstützt) ----
 ENV_DB_PATH = "DEADLOCK_DB_PATH"   # kompletter Pfad zur DB-Datei (höchste Prio)
 ENV_DB_DIR  = "DEADLOCK_DB_DIR"    # nur Verzeichnis; Datei = deadlock.sqlite3
@@ -81,6 +84,7 @@ def db_path() -> str:
 
 # Praktischer Alias für Altcode:
 DB_PATH: Path = Path(db_path())
+log.debug("DB_PATH alias initialisiert: %s", DB_PATH)
 
 
 # ---------- Verbindung / PRAGMA / Schema ----------
@@ -101,6 +105,7 @@ def connect() -> sqlite3.Connection:
     _ensure_parent(path)
     _DB_PATH_CACHED = path
     DB_PATH = Path(path)  # Alias aktualisieren
+    log.debug("DB_PATH alias aktualisiert: %s", DB_PATH)
 
     _CONN = sqlite3.connect(
         path,

--- a/standalone/hub_interface_bot.py
+++ b/standalone/hub_interface_bot.py
@@ -216,8 +216,8 @@ class FormView(discord.ui.View):
         try:
             if user.voice and user.voice.channel:
                 await user.move_to(ch, reason="Eigener Lane-Channel erstellt")
-        except discord.Forbidden:
-            pass
+        except discord.Forbidden as exc:
+            log.warning("Konnte %s nicht in neuen Voice-Channel verschieben: %s", user.id, exc)
 
         await interaction.response.edit_message(
             content=f"✅ **{ch.name}** wurde erstellt in **{ch.category.name}**.",


### PR DESCRIPTION
## Summary
- add logging around clip submission interface refreshes and command handlers while avoiding silent failures and implicit returns
- audit welcome DM and streamer onboarding flows to capture ignored exceptions and cleanly unwind helper logic
- harden Steam link nudges and the Steam status checker with debug logging so parsing failures and cancellations are visible

## Testing
- python -m compileall cogs main_bot.py service standalone

------
https://chatgpt.com/codex/tasks/task_e_68f8374029f8832fa1bbd87dccff03ec