### PR TITLE
Fix steam URL retrieval in voice nudge

### DIFF
--- a/cogs/steam_link_voice_nudge.py
+++ b/cogs/steam_link_voice_nudge.py
@@ -431,7 +431,7 @@ class SteamLinkVoiceNudge(commands.Cog):
     async def _build_dm_payload(
         self, user: Union[discord.User, discord.Member]
     ) -> Tuple[discord.Embed, _OptionsView]:
-        discord_url, _ = await _fetch_oauth_urls(self.bot, user)
+        discord_url, steam_url = await _fetch_oauth_urls(self.bot, user)
         primary_discord, browser_fallback = _prefer_discord_deeplink(discord_url)
 
         desc = steam_link_detailed_description()


### PR DESCRIPTION
## Summary
- ensure the Steam Link voice nudge DM payload retrieves the Steam login URL returned by the OAuth helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902b33bc974832f87a448b563a40081