### PR TITLE
Handle missing Schnell-Link dependency gracefully

### DIFF
--- a/cogs/steam/__init__.py
+++ b/cogs/steam/__init__.py
@@ -1,13 +1,77 @@
 """Steam cog package exports."""
 
-from .schnelllink import (
-    SCHNELL_LINK_CUSTOM_ID,
-    SchnellLink,
-    SchnellLinkButton,
-    respond_with_schnelllink,
-)
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import discord
+
+log = logging.getLogger(__name__)
+
+try:
+    from .schnelllink import (  # type: ignore
+        SCHNELL_LINK_CUSTOM_ID,
+        SchnellLink,
+        SchnellLinkButton,
+        respond_with_schnelllink,
+    )
+    SCHNELL_LINK_AVAILABLE = True
+except Exception as exc:  # pragma: no cover - fallback wenn aiohttp fehlt
+    log.warning(
+        "Schnell-Link-Utilities nicht verfügbar: %s",
+        exc,
+        exc_info=True,
+    )
+
+    SCHNELL_LINK_AVAILABLE = False
+    SCHNELL_LINK_CUSTOM_ID = "steam:schnelllink-unavailable"
+
+    class SchnellLink:  # type: ignore[override]
+        """Placeholder der klar signalisiert, dass Schnell-Link fehlt."""
+
+        def __init__(self, *_: object, **__: object) -> None:
+            raise RuntimeError(
+                "Schnell-Link-Integration ist nicht verfügbar (aiohttp fehlt?)."
+            )
+
+    class SchnellLinkButton(discord.ui.Button):  # type: ignore[override]
+        def __init__(
+            self,
+            *,
+            label: str = "Schnell-Link derzeit nicht verfügbar",
+            style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+            emoji: Optional[str] = "⚠️",
+            custom_id: Optional[str] = None,
+            row: Optional[int] = None,
+            source: Optional[str] = None,
+        ) -> None:
+            super().__init__(
+                label=label,
+                style=style,
+                emoji=emoji,
+                custom_id=custom_id or SCHNELL_LINK_CUSTOM_ID,
+                row=row,
+                disabled=True,
+            )
+            self._source = source or "schnelllink-unavailable"
+
+    async def respond_with_schnelllink(
+        interaction: discord.Interaction,
+        *,
+        source: Optional[str] = None,
+    ) -> None:
+        message = (
+            "⚠️ Der Schnell-Link-Service ist derzeit nicht verfügbar. "
+            "Bitte verwende die regulären Verknüpfungsoptionen oder wende dich an das Team."
+        )
+        if interaction.response.is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
 
 __all__ = [
+    "SCHNELL_LINK_AVAILABLE",
     "SCHNELL_LINK_CUSTOM_ID",
     "SchnellLink",
     "SchnellLinkButton",

--- a/cogs/steam/beta_invite.py
+++ b/cogs/steam/beta_invite.py
@@ -11,9 +11,9 @@ from discord import app_commands
 from discord.ext import commands
 
 from service import db
+from cogs.steam import SCHNELL_LINK_AVAILABLE, SchnellLinkButton
 from cogs.steam.friend_requests import queue_friend_request
 from cogs.steam.steam_master import SteamTaskClient
-from cogs.steam import SchnellLinkButton
 
 log = logging.getLogger(__name__)
 
@@ -378,10 +378,18 @@ class BetaInviteFlow(commands.Cog):
 
         if not resolved:
             view = self._build_link_prompt_view(interaction.user)
-            await interaction.followup.send(
+            prompt = (
                 "ℹ️ Es ist noch kein Steam-Account mit deinem Discord verknüpft.\n"
-                "Melde dich über „Via Discord bei Steam anmelden“, „Direkt bei Steam anmelden“ oder nutze den Schnell-Link "
-                "und versuche es danach erneut.",
+                "Melde dich über „Via Discord bei Steam anmelden“ oder „Direkt bei Steam anmelden“"
+            )
+            if SCHNELL_LINK_AVAILABLE:
+                prompt += " oder nutze den Schnell-Link"
+            else:
+                prompt += ". Der Schnell-Link ist derzeit nicht verfügbar"
+            prompt += " und versuche es danach erneut."
+
+            await interaction.followup.send(
+                prompt,
                 view=view,
                 ephemeral=True,
             )


### PR DESCRIPTION
## Summary
- guard the Schnell-Link exports so the steam cogs still load when the aiohttp dependency is missing
- surface a disabled Schnell-Link button and adjusted copy in the beta invite command when the quick link service is unavailable

## Testing
- python -m compileall cogs/steam

------
https://chatgpt.com/codex/tasks/task_e_6902c0c5ee48832f80a8af1699b5d2cc