### PR TITLE
Expose detailed Steam Bridge component status in dashboard

### DIFF
--- a/cogs/steam/steam_presence/index.js
+++ b/cogs/steam/steam_presence/index.js
@@ -1199,7 +1199,8 @@ class SteamBridge {
         presence: {
           active_users: this.presenceState.activeUsers.size,
           pending_requests: this.presenceState.pendingRequests
-        }
+        },
+        components: this.getComponentStatuses()
       };
       
       this.database.update('standalone_bot_state', 
@@ -1254,6 +1255,33 @@ class SteamBridge {
       last_error: this.stats.lastError,
       memory_usage_mb: Math.round(process.memoryUsage().rss / 1024 / 1024),
       is_running: this.isRunning
+    };
+  }
+
+  getComponentStatuses() {
+    const steamStatus = this.steamClient ? { ...this.steamClient.getStatus() } : null;
+    const taskStatus = this.taskProcessor ? { ...this.taskProcessor.getStatistics() } : null;
+    const quickInvitesStatus =
+      this.quickInvites && typeof this.quickInvites.getStatus === 'function'
+        ? this.quickInvites.getStatus()
+        : null;
+    const statusAnzeigeStatus =
+      this.statusAnzeige && typeof this.statusAnzeige.getStatus === 'function'
+        ? this.statusAnzeige.getStatus()
+        : null;
+
+    return {
+      steam_client: steamStatus,
+      task_processor: taskStatus,
+      quick_invites: quickInvitesStatus,
+      statusanzeige: statusAnzeigeStatus,
+      presence_tracker: {
+        timer_active: Boolean(this.presenceTimer),
+        pending_requests: this.presenceState.pendingRequests,
+        active_users: this.presenceState.activeUsers.size,
+        last_check_at: this.presenceState.lastCheck || null,
+        interval_ms: CONFIG.presenceCheckInterval
+      }
     };
   }
 

--- a/main_bot.py
+++ b/main_bot.py
@@ -1089,9 +1089,19 @@ class MasterBot(commands.Bot):
             task_counts = _format_task_counts(task_counts_rows)
             quick_counts = _format_quick_counts(quick_counts_rows)
 
+            runtime_payload = payload.get("runtime", {}) if isinstance(payload, dict) else {}
+            steam_payload = payload.get("steam", {}) if isinstance(payload, dict) else {}
+            presence_payload = payload.get("presence", {}) if isinstance(payload, dict) else {}
+            component_payload = payload.get("components", {}) if isinstance(payload, dict) else {}
+            task_snapshot = payload.get("tasks", {}) if isinstance(payload, dict) else {}
+
             return {
                 "state": payload,
-                "runtime": payload.get("runtime", {}),
+                "runtime": runtime_payload,
+                "steam": steam_payload,
+                "presence": presence_payload,
+                "components": component_payload,
+                "task_processor": task_snapshot,
                 "pending_commands": _format_command_rows(pending_rows, include_finished=False),
                 "recent_commands": _format_command_rows(recent_rows, include_finished=True),
                 "tasks": {

--- a/service/dashboard.py
+++ b/service/dashboard.py
@@ -155,6 +155,36 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
         .standalone-metrics strong {
             font-weight: 600;
         }
+        .steam-component-section {
+            margin-top: 0.75rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid rgba(255,255,255,0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+        .steam-component-entry {
+            display: flex;
+            flex-direction: column;
+            gap: 0.15rem;
+            font-size: 0.85rem;
+        }
+        .steam-component-entry > div:first-child {
+            display: flex;
+            align-items: baseline;
+            gap: 0.35rem;
+        }
+        .steam-component-name {
+            font-weight: 600;
+        }
+        .steam-component-status-text {
+            font-weight: 500;
+        }
+        .steam-component-details {
+            color: #adb5bd;
+            font-size: 0.78rem;
+            padding-left: 1.5rem;
+        }
         .standalone-commands {
             margin-top: 0.75rem;
             border-top: 1px solid rgba(255,255,255,0.06);


### PR DESCRIPTION
## Summary
- track Steam Guard requirements and expose per-component health in the Steam Bridge heartbeat payload
- record quick invite auto-ensure and Statusanzeige snapshot metadata so the dashboard can report their state
- extend the Steam standalone dashboard view with component summaries, guard indicators, and styling updates

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690b78ad2238832fb0979658cd17b5b0