### PR TITLE
Add Steam Rank Checker LFG System

### DIFF
--- a/cogs/steam_rank_checker.py
+++ b/cogs/steam_rank_checker.py
@@ -580,11 +580,10 @@ class SteamRankChecker(commands.Cog):
                 if cat_type == "casual" and rank_diff > 2:
                     warning = " ⚠️ (größere Rank-Diff)"
 
-                # Klickbarer Voice Channel Link (Discord URL)
+                # Klickbarer Voice Channel Link (Discord URL) - Discord zeigt das automatisch richtig an
                 vc_url = f"https://discord.com/channels/{GUILD_ID}/{channel.id}"
-                # Zeige Channel Mention (klickbar) + direkten Join-Link
                 vc_lines.append(
-                    f"{cat_emoji} {channel.mention} - {member_count} Spieler{warning} → [Beitreten]({vc_url})"
+                    f"{cat_emoji} [{channel.name}]({vc_url}) - {member_count} Spieler{warning}"
                 )
 
             embed.add_field(


### PR DESCRIPTION
Implements a Discord bot that monitors a specific LFG channel and pings online players based on their Deadlock rank and Steam status.

Features:
- Monitors configured text channel for LFG messages
- Checks author's Discord rank
- Queries Steam links and live player state
- Filters online players by rank tolerance (±2 by default)
- Pings matching players with detailed status (lobby/match)
- Rate limiting to prevent spam
- Admin status command

The bot integrates with existing Steam presence tracking and rank management systems.