### PR TITLE
Potential fix for code scanning alert no. 436: Information exposure through an exception

### DIFF
--- a/cogs/twitch/dashboard/raid.py
+++ b/cogs/twitch/dashboard/raid.py
@@ -138,12 +138,12 @@ class DashboardRaidMixin:
         except Exception as e:
             log.exception("OAuth callback error for %s", login)
             return web.Response(
-                text=f"""
+                text="""
                 <html>
                 <head><title>Fehler</title></head>
                 <body style="font-family: sans-serif; max-width: 600px; margin: 50px auto;">
                     <h1>❌ Fehler bei der Autorisierung</h1>
-                    <p>Ein Fehler ist aufgetreten: {str(e)}</p>
+                    <p>Ein interner Fehler ist aufgetreten. Bitte versuche es später erneut.</p>
                     <p><a href="/twitch/raids">Zurück</a></p>
                 </body>
                 </html>


### PR DESCRIPTION
Potential fix for [https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/436](https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/436)

To fix the problem, the user-visible response should not contain the raw exception message. Instead, the code should return a generic, non-sensitive error message while logging the detailed exception server-side (which it already does with `log.exception`). This aligns with the recommendation to avoid exposing stack traces or internal details to end users.

The best minimal fix, without changing existing functionality beyond the error text, is:
- Keep the `log.exception("OAuth callback error for %s", login)` call as-is so that full debug information remains available in logs.
- Replace `"{str(e)}"` in the HTML response with a generic error message in German that does not reveal internal details, for example: `"Ein interner Fehler ist aufgetreten. Bitte versuche es später erneut."`
- Do not alter control flow, HTTP status code, or content type; just change the error text portion inside the HTML so the overall behavior of the endpoint remains the same, aside from no longer leaking exception details.

Only one region in `cogs/twitch/dashboard/raid.py` needs editing: the `except Exception as e:` block in `raid_oauth_callback`, specifically the `<p>Ein Fehler ist aufgetreten: {str(e)}</p>` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
