### PR TITLE
Potential fix for code scanning alert no. 435: Reflected server-side cross-site scripting

### DIFF
--- a/cogs/twitch/dashboard/raid.py
+++ b/cogs/twitch/dashboard/raid.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from aiohttp import web
-
+import html
 if TYPE_CHECKING:
     from ..raid_manager import RaidBot
 
@@ -65,7 +65,7 @@ class DashboardRaidMixin:
                 <head><title>Autorisierung fehlgeschlagen</title></head>
                 <body style="font-family: sans-serif; max-width: 600px; margin: 50px auto;">
                     <h1>❌ Autorisierung fehlgeschlagen</h1>
-                    <p>Fehler: {error}</p>
+                    <p>Fehler: {html.escape(error, quote=True)}</p>
                     <p><a href="/twitch/raids">Zurück</a></p>
                 </body>
                 </html>


### PR DESCRIPTION
Potential fix for [https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/435](https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/435)

In general, to fix this kind of issue, all user-controlled values that are injected into HTML must be HTML-escaped before inclusion, so that characters like `<`, `>`, `&`, `"`, and `'` cannot break out of their intended context and start new HTML/JS. In Python, the standard way is to use `html.escape()` from the standard library, or an equivalent escaping function provided by the framework.

The best, minimal-impact fix here is to HTML-escape the `error` parameter before interpolating it into the f-string. We can import `html` from the standard library at the top of this file and then wrap `error` with `html.escape(error, quote=True)`. This preserves the existing functionality (the error message is still shown) but ensures that any HTML or script content in `error` is rendered as plain text. Concretely, in `raid_oauth_callback`, we change the line `<p>Fehler: {error}</p>` to `<p>Fehler: {html.escape(error, quote=True)}</p>`, and add `import html` near the top of the file. No other logic needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
