### PR TITLE
Potential fix for code scanning alert no. 438: Wrong number of arguments in a call

### DIFF
--- a/cogs/deadlock_team_balancer.py
+++ b/cogs/deadlock_team_balancer.py
@@ -383,7 +383,7 @@ class DeadlockTeamBalancer(commands.Cog):
         role_nm, role_val = _rank_from_roles(member)
         db_nm, db_val = ("Obscurus", 0)
         if self.db:
-            db_nm, db_val = await _fetch_rank_from_db(self.db, member.id)
+            db_nm, db_val = await _fetch_rank_from_db(member.id)
         emb = discord.Embed(title=f"📊 Rank-Status: {member.display_name}", color=discord.Color.blue())
         emb.add_field(name="🎯 Aktueller Rank", value=f"**{nm}** ({val})", inline=True)
         emb.add_field(name="🎭 Discord-Rollen", value=f"{role_nm} ({role_val})" if role_val else "Keine Rank-Rolle", inline=True)


### PR DESCRIPTION
Potential fix for [https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/438](https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/438)

In general, a "wrong number of arguments" error is fixed by making the function call’s arguments match the function’s parameter list: either change the call to pass the correct number of arguments, or change the function definition if the call pattern is correct. Here, the function `_fetch_rank_from_db` is already implemented to use the global `db` import (`from service import db`) and only needs a `user_id`. Therefore, the safest fix that preserves existing behavior is to adjust the call site to pass only the `member.id` argument.

Concretely, in `cogs/deadlock_team_balancer.py` inside the `balance_status` command (around line 385–387), change:

```py
if self.db:
    db_nm, db_val = await _fetch_rank_from_db(self.db, member.id)
```

to:

```py
if self.db:
    db_nm, db_val = await _fetch_rank_from_db(member.id)
```

This keeps the conditional check on `self.db` (so we don’t alter the logic that only queries when a DB is configured), but calls `_fetch_rank_from_db` with exactly the single `user_id` parameter it expects. No new imports, helpers, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
