### PR TITLE
Potential fix for code scanning alert no. 478: Variable defined multiple times

### DIFF
--- a/cogs/twitch/twitch_chat_bot.py
+++ b/cogs/twitch/twitch_chat_bot.py
@@ -365,13 +365,6 @@ if not TWITCHIO_AVAILABLE:
         """Stub, damit Import-Caller nicht crashen, wenn twitchio fehlt."""
         pass
 
-    async def create_twitch_chat_bot(*args, **kwargs):  # type: ignore[redefinition]
-        log.warning(
-            "TwitchIO nicht installiert – Twitch Chat Bot wird übersprungen. "
-            "Installation optional: pip install twitchio"
-        )
-        return None
-
 async def create_twitch_chat_bot(
     client_id: str,
     client_secret: str,
@@ -383,6 +376,17 @@ async def create_twitch_chat_bot(
     """
     Erstellt einen Twitch Chat Bot mit Bot-Account-Token.
 
+    Env-Variablen:
+    - TWITCH_BOT_TOKEN: OAuth-Token für den Bot-Account
+    """
+    if not TWITCHIO_AVAILABLE:
+        log.warning(
+            "TwitchIO nicht installiert – Twitch Chat Bot wird übersprungen. "
+            "Installation optional: pip install twitchio"
+        )
+        return None
+
+    """
     Env-Variablen:
     - TWITCH_BOT_TOKEN: OAuth-Token für den Bot-Account
     - TWITCH_BOT_TOKEN_FILE: Optionaler Dateipfad, der das OAuth-Token enthaelt


### PR DESCRIPTION
Potential fix for [https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/478](https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/478)

In general, when a variable (or function name) is assigned multiple times without any intervening use, you should remove or merge the earlier assignment so that there is a single, authoritative definition. Here, we should keep the fully featured `create_twitch_chat_bot` at line 375 and integrate the “twitchio missing” behavior into it, so there is only one function named `create_twitch_chat_bot`.

Concretely for `cogs/twitch/twitch_chat_bot.py`:

- Delete the stub `async def create_twitch_chat_bot(*args, **kwargs):  # type: ignore[redefinition]` inside the `if not TWITCHIO_AVAILABLE:` block (lines 368–373).
- Modify the real `create_twitch_chat_bot` (lines 375–382) so that it first checks `TWITCHIO_AVAILABLE`. If `twitchio` is not available, it should log the same warning message currently in the stub and return `None`. If `twitchio` is available, it should proceed as it currently does (the rest of the function body, which is not shown, remains unchanged).
- This preserves behavior (callers still get `None` and a warning when `twitchio` is missing) while eliminating the redundant earlier assignment to `create_twitch_chat_bot`.

No new imports or helper methods are needed; we just adjust control flow in the existing function definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
