### PR TITLE
Potential fix for code scanning alert no. 443: Variable defined multiple times

### DIFF
--- a/cogs/voice_activity_tracker.py
+++ b/cogs/voice_activity_tracker.py
@@ -462,7 +462,6 @@ class VoiceActivityTrackerCog(commands.Cog):
         message_text = "\n\n".join(lines)
 
 
-        status = "error"
         error_message = None
         prompt_message_id = None
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/443](https://github.com/NaniDerEchte2/Deadlock-Bots/security/code-scanning/443)

In general, to fix “variable defined multiple times” issues where an earlier assignment is always overwritten before any use, you remove the redundant initial assignment (or refactor control flow so that the initial assignment is actually meaningful). This keeps the code clearer and avoids suggesting behavior that never occurs.

For this specific case in `cogs/voice_activity_tracker.py`, the best fix is to delete the initial `status = "error"` assignment on line 465 while keeping the other initializations (`error_message = None`, `prompt_message_id = None`) as they are used later. The `try`/`except` block already assigns `status` in all cases: `"sent"` in the success path, `"forbidden"` on `discord.Forbidden`, and `"error"` (the same value as the default) on a generic `Exception`. Thus, removing the earlier `"error"` default does not change behavior.

Concretely:
- In `cogs/voice_activity_tracker.py`, locate the block starting at line 465.
- Remove the line `status = "error"`.
- Leave `error_message = None` and `prompt_message_id = None` unchanged.
No new imports, helpers, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
